### PR TITLE
Making Message struct initializer public.

### DIFF
--- a/SlackKit/Sources/Message.swift
+++ b/SlackKit/Sources/Message.swift
@@ -55,7 +55,7 @@ public class Message {
     internal(set) public var reactions = [String: Reaction]()
     internal(set) public var attachments: [Attachment] = []
     
-    init?(message: [String: AnyObject]?) {
+    public init?(message: [String: AnyObject]?) {
         subtype = message?["subtype"] as? String
         ts = message?["ts"] as? String
         user = message?["user"] as? String


### PR DESCRIPTION
Making the Message struct initializer public so that apps/programs using SlackKit and properly  parse/create `Message`s as a response to web api calls.
