### PR TITLE
Fix circular dependencies

### DIFF
--- a/SlackKit.xcodeproj/project.pbxproj
+++ b/SlackKit.xcodeproj/project.pbxproj
@@ -19,8 +19,6 @@
 		26BBA1961C398E3C00BF7225 /* Client.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BBA1891C398E3C00BF7225 /* Client.swift */; };
 		26BBA1971C398E3C00BF7225 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BBA18A1C398E3C00BF7225 /* Event.swift */; };
 		26BBA1981C398E3C00BF7225 /* EventDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BBA18B1C398E3C00BF7225 /* EventDelegate.swift */; };
-		26BBA1991C398E3C00BF7225 /* EventDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BBA18C1C398E3C00BF7225 /* EventDispatcher.swift */; };
-		26BBA19A1C398E3C00BF7225 /* EventHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BBA18D1C398E3C00BF7225 /* EventHandler.swift */; };
 		26BBA19B1C398E3C00BF7225 /* File.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BBA18E1C398E3C00BF7225 /* File.swift */; };
 		26BBA19C1C398E3C00BF7225 /* Message.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BBA18F1C398E3C00BF7225 /* Message.swift */; };
 		26BBA19D1C398E3C00BF7225 /* Team.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BBA1901C398E3C00BF7225 /* Team.swift */; };
@@ -29,6 +27,8 @@
 		26BBA1A01C398E3C00BF7225 /* UserGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BBA1931C398E3C00BF7225 /* UserGroup.swift */; };
 		26DF40351C7A0FA300E19241 /* Attachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DF40341C7A0FA300E19241 /* Attachment.swift */; };
 		26F4BAC31C9DEBD1000910BA /* Leaderboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F4BAC21C9DEBD1000910BA /* Leaderboard.swift */; };
+		C1A85FF91CE3BCEF00756C40 /* EventDispatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A85FF71CE3BCEF00756C40 /* EventDispatching.swift */; };
+		C1A85FFA1CE3BCEF00756C40 /* EventHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A85FF81CE3BCEF00756C40 /* EventHandling.swift */; };
 		FFE3AC870D1C42EF276CCA2D /* Pods_SlackKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 407A2ABFC0611867E2BE34D0 /* Pods_SlackKit.framework */; };
 /* End PBXBuildFile section */
 
@@ -50,8 +50,6 @@
 		26BBA1891C398E3C00BF7225 /* Client.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Client.swift; path = Sources/Client.swift; sourceTree = "<group>"; };
 		26BBA18A1C398E3C00BF7225 /* Event.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Event.swift; path = Sources/Event.swift; sourceTree = "<group>"; };
 		26BBA18B1C398E3C00BF7225 /* EventDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EventDelegate.swift; path = Sources/EventDelegate.swift; sourceTree = "<group>"; };
-		26BBA18C1C398E3C00BF7225 /* EventDispatcher.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EventDispatcher.swift; path = Sources/EventDispatcher.swift; sourceTree = "<group>"; };
-		26BBA18D1C398E3C00BF7225 /* EventHandler.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EventHandler.swift; path = Sources/EventHandler.swift; sourceTree = "<group>"; };
 		26BBA18E1C398E3C00BF7225 /* File.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = File.swift; path = Sources/File.swift; sourceTree = "<group>"; };
 		26BBA18F1C398E3C00BF7225 /* Message.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Message.swift; path = Sources/Message.swift; sourceTree = "<group>"; };
 		26BBA1901C398E3C00BF7225 /* Team.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Team.swift; path = Sources/Team.swift; sourceTree = "<group>"; };
@@ -62,6 +60,8 @@
 		26F4BAC21C9DEBD1000910BA /* Leaderboard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Leaderboard.swift; sourceTree = "<group>"; };
 		407A2ABFC0611867E2BE34D0 /* Pods_SlackKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SlackKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4347F92F3932C96C23B10B2A /* Pods-SlackKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SlackKit.release.xcconfig"; path = "Pods/Target Support Files/Pods-SlackKit/Pods-SlackKit.release.xcconfig"; sourceTree = "<group>"; };
+		C1A85FF71CE3BCEF00756C40 /* EventDispatching.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EventDispatching.swift; path = Sources/EventDispatching.swift; sourceTree = "<group>"; };
+		C1A85FF81CE3BCEF00756C40 /* EventHandling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EventHandling.swift; path = Sources/EventHandling.swift; sourceTree = "<group>"; };
 		F59B6A12F1C4C4E24C58E1BF /* Pods-SlackKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SlackKit.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SlackKit/Pods-SlackKit.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -128,6 +128,8 @@
 		2661A6811BBF60E60026F67B /* SlackKit */ = {
 			isa = PBXGroup;
 			children = (
+				C1A85FF71CE3BCEF00756C40 /* EventDispatching.swift */,
+				C1A85FF81CE3BCEF00756C40 /* EventHandling.swift */,
 				26DF40341C7A0FA300E19241 /* Attachment.swift */,
 				26BBA1871C398E3C00BF7225 /* Bot.swift */,
 				26BBA1881C398E3C00BF7225 /* Channel.swift */,
@@ -135,8 +137,6 @@
 				260EC2301C4DC61D0093B253 /* ClientExtensions.swift */,
 				26BBA18A1C398E3C00BF7225 /* Event.swift */,
 				26BBA18B1C398E3C00BF7225 /* EventDelegate.swift */,
-				26BBA18C1C398E3C00BF7225 /* EventDispatcher.swift */,
-				26BBA18D1C398E3C00BF7225 /* EventHandler.swift */,
 				26BBA18E1C398E3C00BF7225 /* File.swift */,
 				26BBA18F1C398E3C00BF7225 /* Message.swift */,
 				260EC2311C4DC61D0093B253 /* NetworkInterface.swift */,
@@ -313,14 +313,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				26BBA1991C398E3C00BF7225 /* EventDispatcher.swift in Sources */,
 				26BBA1951C398E3C00BF7225 /* Channel.swift in Sources */,
 				26BBA19F1C398E3C00BF7225 /* User.swift in Sources */,
 				26BBA19E1C398E3C00BF7225 /* Types.swift in Sources */,
 				26BBA1961C398E3C00BF7225 /* Client.swift in Sources */,
-				26BBA19A1C398E3C00BF7225 /* EventHandler.swift in Sources */,
 				26BBA1971C398E3C00BF7225 /* Event.swift in Sources */,
 				26BBA1941C398E3C00BF7225 /* Bot.swift in Sources */,
+				C1A85FF91CE3BCEF00756C40 /* EventDispatching.swift in Sources */,
 				26BBA19B1C398E3C00BF7225 /* File.swift in Sources */,
 				260EC2351C4DC61D0093B253 /* SlackWebAPI.swift in Sources */,
 				26DF40351C7A0FA300E19241 /* Attachment.swift in Sources */,
@@ -329,6 +328,7 @@
 				260EC2331C4DC61D0093B253 /* ClientExtensions.swift in Sources */,
 				26BBA1A01C398E3C00BF7225 /* UserGroup.swift in Sources */,
 				2601D61B1C7646B80012BF22 /* SlackWebAPIErrorDispatcher.swift in Sources */,
+				C1A85FFA1CE3BCEF00756C40 /* EventHandling.swift in Sources */,
 				260EC2341C4DC61D0093B253 /* NetworkInterface.swift in Sources */,
 				26BBA1981C398E3C00BF7225 /* EventDelegate.swift in Sources */,
 			);

--- a/SlackKit.xcodeproj/project.pbxproj
+++ b/SlackKit.xcodeproj/project.pbxproj
@@ -11,7 +11,7 @@
 		2601D6271C7688610012BF22 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2601D6261C7688610012BF22 /* AppDelegate.swift */; };
 		2601D6291C7688610012BF22 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2601D6281C7688610012BF22 /* Assets.xcassets */; };
 		2601D62C1C7688610012BF22 /* MainMenu.xib in Resources */ = {isa = PBXBuildFile; fileRef = 2601D62A1C7688610012BF22 /* MainMenu.xib */; };
-		260EC2331C4DC61D0093B253 /* ClientExtensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260EC2301C4DC61D0093B253 /* ClientExtensions.swift */; };
+		260EC2331C4DC61D0093B253 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260EC2301C4DC61D0093B253 /* Extensions.swift */; };
 		260EC2341C4DC61D0093B253 /* NetworkInterface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260EC2311C4DC61D0093B253 /* NetworkInterface.swift */; };
 		260EC2351C4DC61D0093B253 /* SlackWebAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = 260EC2321C4DC61D0093B253 /* SlackWebAPI.swift */; };
 		26BBA1941C398E3C00BF7225 /* Bot.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BBA1871C398E3C00BF7225 /* Bot.swift */; };
@@ -27,8 +27,9 @@
 		26BBA1A01C398E3C00BF7225 /* UserGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26BBA1931C398E3C00BF7225 /* UserGroup.swift */; };
 		26DF40351C7A0FA300E19241 /* Attachment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26DF40341C7A0FA300E19241 /* Attachment.swift */; };
 		26F4BAC31C9DEBD1000910BA /* Leaderboard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F4BAC21C9DEBD1000910BA /* Leaderboard.swift */; };
-		C1A85FF91CE3BCEF00756C40 /* EventDispatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A85FF71CE3BCEF00756C40 /* EventDispatching.swift */; };
-		C1A85FFA1CE3BCEF00756C40 /* EventHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A85FF81CE3BCEF00756C40 /* EventHandling.swift */; };
+		C16C987A1CE7D3DD00692776 /* Client+Utilities.swift in Sources */ = {isa = PBXBuildFile; fileRef = C16C98791CE7D3DD00692776 /* Client+Utilities.swift */; };
+		C1A85FF91CE3BCEF00756C40 /* Client+EventDispatching.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A85FF71CE3BCEF00756C40 /* Client+EventDispatching.swift */; };
+		C1A85FFA1CE3BCEF00756C40 /* Client+EventHandling.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A85FF81CE3BCEF00756C40 /* Client+EventHandling.swift */; };
 		FFE3AC870D1C42EF276CCA2D /* Pods_SlackKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 407A2ABFC0611867E2BE34D0 /* Pods_SlackKit.framework */; };
 /* End PBXBuildFile section */
 
@@ -40,7 +41,7 @@
 		2601D62B1C7688610012BF22 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/MainMenu.xib; sourceTree = "<group>"; };
 		2601D62D1C7688610012BF22 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		26072A341BB48B3A00CD650C /* SlackKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = SlackKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		260EC2301C4DC61D0093B253 /* ClientExtensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = ClientExtensions.swift; path = Sources/ClientExtensions.swift; sourceTree = "<group>"; };
+		260EC2301C4DC61D0093B253 /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = Extensions.swift; path = Sources/Extensions.swift; sourceTree = "<group>"; };
 		260EC2311C4DC61D0093B253 /* NetworkInterface.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = NetworkInterface.swift; path = Sources/NetworkInterface.swift; sourceTree = "<group>"; };
 		260EC2321C4DC61D0093B253 /* SlackWebAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = SlackWebAPI.swift; path = Sources/SlackWebAPI.swift; sourceTree = "<group>"; };
 		2661A6A41BBF62FF0026F67B /* SlackKit.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = SlackKit.h; sourceTree = "<group>"; };
@@ -60,8 +61,9 @@
 		26F4BAC21C9DEBD1000910BA /* Leaderboard.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Leaderboard.swift; sourceTree = "<group>"; };
 		407A2ABFC0611867E2BE34D0 /* Pods_SlackKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_SlackKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		4347F92F3932C96C23B10B2A /* Pods-SlackKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SlackKit.release.xcconfig"; path = "Pods/Target Support Files/Pods-SlackKit/Pods-SlackKit.release.xcconfig"; sourceTree = "<group>"; };
-		C1A85FF71CE3BCEF00756C40 /* EventDispatching.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EventDispatching.swift; path = Sources/EventDispatching.swift; sourceTree = "<group>"; };
-		C1A85FF81CE3BCEF00756C40 /* EventHandling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = EventHandling.swift; path = Sources/EventHandling.swift; sourceTree = "<group>"; };
+		C16C98791CE7D3DD00692776 /* Client+Utilities.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Client+Utilities.swift"; path = "Sources/Client+Utilities.swift"; sourceTree = "<group>"; };
+		C1A85FF71CE3BCEF00756C40 /* Client+EventDispatching.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Client+EventDispatching.swift"; path = "Sources/Client+EventDispatching.swift"; sourceTree = "<group>"; };
+		C1A85FF81CE3BCEF00756C40 /* Client+EventHandling.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = "Client+EventHandling.swift"; path = "Sources/Client+EventHandling.swift"; sourceTree = "<group>"; };
 		F59B6A12F1C4C4E24C58E1BF /* Pods-SlackKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-SlackKit.debug.xcconfig"; path = "Pods/Target Support Files/Pods-SlackKit/Pods-SlackKit.debug.xcconfig"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -128,15 +130,16 @@
 		2661A6811BBF60E60026F67B /* SlackKit */ = {
 			isa = PBXGroup;
 			children = (
-				C1A85FF71CE3BCEF00756C40 /* EventDispatching.swift */,
-				C1A85FF81CE3BCEF00756C40 /* EventHandling.swift */,
 				26DF40341C7A0FA300E19241 /* Attachment.swift */,
 				26BBA1871C398E3C00BF7225 /* Bot.swift */,
 				26BBA1881C398E3C00BF7225 /* Channel.swift */,
 				26BBA1891C398E3C00BF7225 /* Client.swift */,
-				260EC2301C4DC61D0093B253 /* ClientExtensions.swift */,
+				C1A85FF81CE3BCEF00756C40 /* Client+EventHandling.swift */,
+				C1A85FF71CE3BCEF00756C40 /* Client+EventDispatching.swift */,
+				C16C98791CE7D3DD00692776 /* Client+Utilities.swift */,
 				26BBA18A1C398E3C00BF7225 /* Event.swift */,
 				26BBA18B1C398E3C00BF7225 /* EventDelegate.swift */,
+				260EC2301C4DC61D0093B253 /* Extensions.swift */,
 				26BBA18E1C398E3C00BF7225 /* File.swift */,
 				26BBA18F1C398E3C00BF7225 /* Message.swift */,
 				260EC2311C4DC61D0093B253 /* NetworkInterface.swift */,
@@ -313,22 +316,23 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				C16C987A1CE7D3DD00692776 /* Client+Utilities.swift in Sources */,
 				26BBA1951C398E3C00BF7225 /* Channel.swift in Sources */,
 				26BBA19F1C398E3C00BF7225 /* User.swift in Sources */,
 				26BBA19E1C398E3C00BF7225 /* Types.swift in Sources */,
 				26BBA1961C398E3C00BF7225 /* Client.swift in Sources */,
 				26BBA1971C398E3C00BF7225 /* Event.swift in Sources */,
 				26BBA1941C398E3C00BF7225 /* Bot.swift in Sources */,
-				C1A85FF91CE3BCEF00756C40 /* EventDispatching.swift in Sources */,
+				C1A85FF91CE3BCEF00756C40 /* Client+EventDispatching.swift in Sources */,
 				26BBA19B1C398E3C00BF7225 /* File.swift in Sources */,
 				260EC2351C4DC61D0093B253 /* SlackWebAPI.swift in Sources */,
 				26DF40351C7A0FA300E19241 /* Attachment.swift in Sources */,
 				26BBA19C1C398E3C00BF7225 /* Message.swift in Sources */,
 				26BBA19D1C398E3C00BF7225 /* Team.swift in Sources */,
-				260EC2331C4DC61D0093B253 /* ClientExtensions.swift in Sources */,
+				260EC2331C4DC61D0093B253 /* Extensions.swift in Sources */,
 				26BBA1A01C398E3C00BF7225 /* UserGroup.swift in Sources */,
 				2601D61B1C7646B80012BF22 /* SlackWebAPIErrorDispatcher.swift in Sources */,
-				C1A85FFA1CE3BCEF00756C40 /* EventHandling.swift in Sources */,
+				C1A85FFA1CE3BCEF00756C40 /* Client+EventHandling.swift in Sources */,
 				260EC2341C4DC61D0093B253 /* NetworkInterface.swift in Sources */,
 				26BBA1981C398E3C00BF7225 /* EventDelegate.swift in Sources */,
 			);

--- a/SlackKit/Sources/Client+EventDispatching.swift
+++ b/SlackKit/Sources/Client+EventDispatching.swift
@@ -1,5 +1,5 @@
 //
-// EventDispatching.swift
+// Client+EventDispatching.swift
 //
 // Copyright © 2016 Peter Zignego. All rights reserved.
 //

--- a/SlackKit/Sources/Client+EventHandling.swift
+++ b/SlackKit/Sources/Client+EventHandling.swift
@@ -1,5 +1,5 @@
 //
-// EventHandling.swift
+// Client+EventHandling.swift
 //
 // Copyright © 2016 Peter Zignego. All rights reserved.
 //

--- a/SlackKit/Sources/Client+Utilities.swift
+++ b/SlackKit/Sources/Client+Utilities.swift
@@ -1,5 +1,5 @@
 //
-// ClientExtensions.swift
+// Client+EventDispatching.swift
 //
 // Copyright © 2016 Peter Zignego. All rights reserved.
 //
@@ -23,17 +23,17 @@
 
 import Foundation
 
-extension Client {
-    
+public extension Client {
+
     //MARK: - User & Channel
     public func getChannelIDByName(name: String) -> String? {
         return channels.filter{$0.1.name == stripString(name)}.first?.0
     }
-    
+
     public func getUserIDByName(name: String) -> String? {
         return users.filter{$0.1.name == stripString(name)}.first?.0
     }
-    
+
     public func getImIDForUserWithID(id: String, success: (imID: String?)->Void, failure: (error: SlackError)->Void) {
         let ims = channels.filter{$0.1.isIM == true}
         let channel = ims.filter{$0.1.user == id}.first
@@ -43,7 +43,7 @@ extension Client {
             webAPI.openIM(id, success: success, failure: failure)
         }
     }
-    
+
     //MARK: - Utilities
     internal func stripString(string: String) -> String? {
         var strippedString = string
@@ -52,45 +52,4 @@ extension Client {
         }
         return strippedString
     }
-}
-
-public enum AttachmentColor: String {
-    case Good = "good"
-    case Warning = "warning"
-    case Danger = "danger"
-}
-
-public extension NSDate {
-
-    func slackTimestamp() -> Double {
-        return NSNumber(double: timeIntervalSince1970).doubleValue
-    }
-    
-}
-
-internal extension String {
-    
-    func slackFormatEscaping() -> String {
-        var escapedString = stringByReplacingOccurrencesOfString("&", withString: "&amp;")
-        escapedString = stringByReplacingOccurrencesOfString("<", withString: "&lt;")
-        escapedString = stringByReplacingOccurrencesOfString(">", withString: "&gt;")
-        return escapedString
-    }
-
-}
-
-internal extension Array {
-
-    func objectArrayFromDictionaryArray<T>(intializer:([String: AnyObject])->T?) -> [T] {
-        var returnValue = [T]()
-        for object in self {
-            if let dictionary = object as? [String: AnyObject] {
-                if let value = intializer(dictionary) {
-                    returnValue.append(value)
-                }
-            }
-        }
-        return returnValue
-    }
-    
 }

--- a/SlackKit/Sources/Client.swift
+++ b/SlackKit/Sources/Client.swift
@@ -64,8 +64,7 @@ public class Client: WebSocketDelegate {
 
     internal var webSocket: WebSocket?
     internal let api = NetworkInterface()
-    private var dispatcher: EventDispatcher?
-    
+
     private let pingPongQueue = dispatch_queue_create("com.launchsoft.SlackKit", DISPATCH_QUEUE_SERIAL)
     internal var ping: Double?
     internal var pong: Double?
@@ -82,7 +81,6 @@ public class Client: WebSocketDelegate {
         self.pingInterval = pingInterval
         self.timeout = timeout
         self.reconnect = reconnect
-        dispatcher = EventDispatcher(client: self)
         webAPI.rtmStart(simpleLatest, noUnreads: noUnreads, mpimAware: mpimAware, success: {
             (response) -> Void in
             self.initialSetup(response)
@@ -255,7 +253,6 @@ public class Client: WebSocketDelegate {
         connected = false
         authenticated = false
         webSocket = nil
-        dispatcher = nil
         authenticatedUser = nil
         slackEventsDelegate?.clientDisconnected()
         if reconnect == true {
@@ -269,7 +266,7 @@ public class Client: WebSocketDelegate {
         }
         do {
             if let json = try NSJSONSerialization.JSONObjectWithData(data, options: NSJSONReadingOptions.AllowFragments) as? [String: AnyObject] {
-                dispatcher?.dispatch(json)
+                dispatch(json)
             }
         }
         catch _ {

--- a/SlackKit/Sources/Client.swift
+++ b/SlackKit/Sources/Client.swift
@@ -39,18 +39,18 @@ public class Client: WebSocketDelegate {
     internal(set) public var sentMessages = [String: Message]()
     
     //MARK: - Delegates
-    public var slackEventsDelegate: SlackEventsDelegate?
-    public var messageEventsDelegate: MessageEventsDelegate?
-    public var doNotDisturbEventsDelegate: DoNotDisturbEventsDelegate?
-    public var channelEventsDelegate: ChannelEventsDelegate?
-    public var groupEventsDelegate: GroupEventsDelegate?
-    public var fileEventsDelegate: FileEventsDelegate?
-    public var pinEventsDelegate: PinEventsDelegate?
-    public var starEventsDelegate: StarEventsDelegate?
-    public var reactionEventsDelegate: ReactionEventsDelegate?
-    public var teamEventsDelegate: TeamEventsDelegate?
-    public var subteamEventsDelegate: SubteamEventsDelegate?
-    public var teamProfileEventsDelegate: TeamProfileEventsDelegate?
+    public weak var slackEventsDelegate: SlackEventsDelegate?
+    public weak var messageEventsDelegate: MessageEventsDelegate?
+    public weak var doNotDisturbEventsDelegate: DoNotDisturbEventsDelegate?
+    public weak var channelEventsDelegate: ChannelEventsDelegate?
+    public weak var groupEventsDelegate: GroupEventsDelegate?
+    public weak var fileEventsDelegate: FileEventsDelegate?
+    public weak var pinEventsDelegate: PinEventsDelegate?
+    public weak var starEventsDelegate: StarEventsDelegate?
+    public weak var reactionEventsDelegate: ReactionEventsDelegate?
+    public weak var teamEventsDelegate: TeamEventsDelegate?
+    public weak var subteamEventsDelegate: SubteamEventsDelegate?
+    public weak var teamProfileEventsDelegate: TeamProfileEventsDelegate?
     
     public var token = "SLACK_AUTH_TOKEN"
     

--- a/SlackKit/Sources/EventDelegate.swift
+++ b/SlackKit/Sources/EventDelegate.swift
@@ -23,7 +23,7 @@
 
 import Foundation
 
-public protocol SlackEventsDelegate {
+public protocol SlackEventsDelegate: class {
     func clientConnectionFailed(error: SlackError)
     func clientConnected()
     func clientDisconnected()
@@ -34,14 +34,14 @@ public protocol SlackEventsDelegate {
     func botEvent(bot: Bot)
 }
 
-public protocol MessageEventsDelegate {
+public protocol MessageEventsDelegate: class {
     func messageSent(message: Message)
     func messageReceived(message: Message)
     func messageChanged(message: Message)
     func messageDeleted(message: Message?)
 }
 
-public protocol ChannelEventsDelegate {
+public protocol ChannelEventsDelegate: class {
     func userTyping(channel: Channel?, user: User?)
     func channelMarked(channel: Channel, timestamp: String?)
     func channelCreated(channel: Channel)
@@ -53,16 +53,16 @@ public protocol ChannelEventsDelegate {
     func channelLeft(channel: Channel)
 }
 
-public protocol DoNotDisturbEventsDelegate {
+public protocol DoNotDisturbEventsDelegate: class {
     func doNotDisturbUpdated(dndStatus: DoNotDisturbStatus)
     func doNotDisturbUserUpdated(dndStatus: DoNotDisturbStatus, user: User?)
 }
 
-public protocol GroupEventsDelegate {
+public protocol GroupEventsDelegate: class {
     func groupOpened(group: Channel)
 }
 
-public protocol FileEventsDelegate {
+public protocol FileEventsDelegate: class {
     func fileProcessed(file: File)
     func fileMadePrivate(file: File)
     func fileDeleted(file: File)
@@ -71,21 +71,21 @@ public protocol FileEventsDelegate {
     func fileCommentDeleted(file: File, comment: Comment)
 }
 
-public protocol PinEventsDelegate {
+public protocol PinEventsDelegate: class {
     func itemPinned(item: Item?, channel: Channel?)
     func itemUnpinned(item: Item?, channel: Channel?)
 }
 
-public protocol StarEventsDelegate {
+public protocol StarEventsDelegate: class {
     func itemStarred(item: Item, star: Bool)
 }
 
-public protocol ReactionEventsDelegate {
+public protocol ReactionEventsDelegate: class {
     func reactionAdded(reaction: String?, item: Item?, itemUser: String?)
     func reactionRemoved(reaction: String?, item: Item?, itemUser: String?)
 }
 
-public protocol TeamEventsDelegate {
+public protocol TeamEventsDelegate: class {
     func teamJoined(user: User)
     func teamPlanChanged(plan: String)
     func teamPreferencesChanged(preference: String, value: AnyObject)
@@ -95,13 +95,13 @@ public protocol TeamEventsDelegate {
     func teamEmojiChanged()
 }
 
-public protocol SubteamEventsDelegate {
+public protocol SubteamEventsDelegate: class {
     func subteamEvent(userGroup: UserGroup)
     func subteamSelfAdded(subteamID: String)
     func subteamSelfRemoved(subteamID: String)
 }
 
-public protocol TeamProfileEventsDelegate {
+public protocol TeamProfileEventsDelegate: class {
     func teamProfileChanged(profile: CustomProfile?)
     func teamProfileDeleted(profile: CustomProfile?)
     func teamProfileReordered(profile: CustomProfile?)

--- a/SlackKit/Sources/EventDispatching.swift
+++ b/SlackKit/Sources/EventDispatching.swift
@@ -1,5 +1,5 @@
 //
-// EventDispatcher.swift
+// EventDispatching.swift
 //
 // Copyright © 2016 Peter Zignego. All rights reserved.
 //
@@ -21,143 +21,137 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-internal class EventDispatcher {
-    let client: Client
-    let handler: EventHandler
-    
-    required init(client: Client) {
-        self.client = client
-        handler = EventHandler(client: client)
-    }
-    
+internal extension Client {
+
     func dispatch(event: [String: AnyObject]) {
         let event = Event(event: event)
         if let type = event.type {
             switch type {
             case .Hello:
-                handler.connected()
+                connected = true
+                slackEventsDelegate?.clientConnected()
             case .Ok:
-                handler.messageSent(event)
+                messageSent(event)
             case .Message:
                 if (event.subtype != nil) {
                     messageDispatcher(event)
                 } else {
-                    handler.messageReceived(event)
+                    messageReceived(event)
                 }
             case .UserTyping:
-                handler.userTyping(event)
+                userTyping(event)
             case .ChannelMarked, .IMMarked, .GroupMarked:
-                handler.channelMarked(event)
+                channelMarked(event)
             case .ChannelCreated, .IMCreated:
-                handler.channelCreated(event)
+                channelCreated(event)
             case .ChannelJoined, .GroupJoined:
-                handler.channelJoined(event)
+                channelJoined(event)
             case .ChannelLeft, .GroupLeft:
-                handler.channelLeft(event)
+                channelLeft(event)
             case .ChannelDeleted:
-                handler.channelDeleted(event)
+                channelDeleted(event)
             case .ChannelRenamed, .GroupRename:
-                handler.channelRenamed(event)
+                channelRenamed(event)
             case .ChannelArchive, .GroupArchive:
-                handler.channelArchived(event, archived: true)
+                channelArchived(event, archived: true)
             case .ChannelUnarchive, .GroupUnarchive:
-                handler.channelArchived(event, archived: false)
+                channelArchived(event, archived: false)
             case .ChannelHistoryChanged, .IMHistoryChanged, .GroupHistoryChanged:
-                handler.channelHistoryChanged(event)
+                channelHistoryChanged(event)
             case .DNDUpdated:
-                handler.doNotDisturbUpdated(event)
+                doNotDisturbUpdated(event)
             case .DNDUpatedUser:
-                handler.doNotDisturbUserUpdated(event)
+                doNotDisturbUserUpdated(event)
             case .IMOpen, .GroupOpen:
-                handler.open(event, open: true)
+                open(event, open: true)
             case .IMClose, .GroupClose:
-                handler.open(event, open: false)
+                open(event, open: false)
             case .FileCreated:
-                handler.processFile(event)
+                processFile(event)
             case .FileShared:
-                handler.processFile(event)
+                processFile(event)
             case .FileUnshared:
-                handler.processFile(event)
+                processFile(event)
             case .FilePublic:
-                handler.processFile(event)
+                processFile(event)
             case .FilePrivate:
-                handler.filePrivate(event)
+                filePrivate(event)
             case .FileChanged:
-                handler.processFile(event)
+                processFile(event)
             case .FileDeleted:
-                handler.deleteFile(event)
+                deleteFile(event)
             case .FileCommentAdded:
-                handler.fileCommentAdded(event)
+                fileCommentAdded(event)
             case .FileCommentEdited:
-                handler.fileCommentEdited(event)
+                fileCommentEdited(event)
             case .FileCommentDeleted:
-                handler.fileCommentDeleted(event)
+                fileCommentDeleted(event)
             case .PinAdded:
-                handler.pinAdded(event)
+                pinAdded(event)
             case .PinRemoved:
-                handler.pinRemoved(event)
+                pinRemoved(event)
             case .Pong:
-                handler.pong(event)
+                pong(event)
             case .PresenceChange:
-                handler.presenceChange(event)
+                presenceChange(event)
             case .ManualPresenceChange:
-                handler.manualPresenceChange(event)
+                manualPresenceChange(event)
             case .PrefChange:
-                handler.changePreference(event)
+                changePreference(event)
             case .UserChange:
-                handler.userChange(event)
+                userChange(event)
             case .TeamJoin:
-                handler.teamJoin(event)
+                teamJoin(event)
             case .StarAdded:
-                handler.itemStarred(event, star: true)
+                itemStarred(event, star: true)
             case .StarRemoved:
-                handler.itemStarred(event, star: false)
+                itemStarred(event, star: false)
             case .ReactionAdded:
-                handler.addedReaction(event)
+                addedReaction(event)
             case .ReactionRemoved:
-                handler.removedReaction(event)
+                removedReaction(event)
             case .EmojiChanged:
-                handler.emojiChanged(event)
+                emojiChanged(event)
             case .CommandsChanged:
                 // This functionality is only used by our web client. 
                 // The other APIs required to support slash command metadata are currently unstable. 
                 // Until they are released other clients should ignore this event.
                 break
             case .TeamPlanChange:
-                handler.teamPlanChange(event)
+                teamPlanChange(event)
             case .TeamPrefChange:
-                handler.teamPreferenceChange(event)
+                teamPreferenceChange(event)
             case .TeamRename:
-                handler.teamNameChange(event)
+                teamNameChange(event)
             case .TeamDomainChange:
-                handler.teamDomainChange(event)
+                teamDomainChange(event)
             case .EmailDomainChange:
-                handler.emailDomainChange(event)
+                emailDomainChange(event)
             case .TeamProfileChange:
-                handler.teamProfileChange(event)
+                teamProfileChange(event)
             case .TeamProfileDelete:
-                handler.teamProfileDeleted(event)
+                teamProfileDeleted(event)
             case .TeamProfileReorder:
-                handler.teamProfileReordered(event)
+                teamProfileReordered(event)
             case .BotAdded:
-                handler.bot(event)
+                bot(event)
             case .BotChanged:
-                handler.bot(event)
+                bot(event)
             case .AccountsChanged:
                 // The accounts_changed event is used by our web client to maintain a list of logged-in accounts.
                 // Other clients should ignore this event.
                 break
             case .TeamMigrationStarted:
-                client.connect(pingInterval: client.pingInterval, timeout: client.timeout, reconnect: client.reconnect)
+                connect(pingInterval: pingInterval, timeout: timeout, reconnect: reconnect)
             case .ReconnectURL:
                 // The reconnect_url event is currently unsupported and experimental.
                 break
             case .SubteamCreated, .SubteamUpdated:
-                handler.subteam(event)
+                subteam(event)
             case .SubteamSelfAdded:
-                handler.subteamAddedSelf(event)
+                subteamAddedSelf(event)
             case.SubteamSelfRemoved:
-                handler.subteamRemovedSelf(event)
+                subteamRemovedSelf(event)
             case .Error:
                 print("Error: \(event)")
                 break
@@ -169,11 +163,11 @@ internal class EventDispatcher {
         let subtype = MessageSubtype(rawValue: event.subtype!)!
         switch subtype {
         case .MessageChanged:
-            handler.messageChanged(event)
+            messageChanged(event)
         case .MessageDeleted:
-            handler.messageDeleted(event)
+            messageDeleted(event)
         default:
-            handler.messageReceived(event)
+            messageReceived(event)
         }
     }
     

--- a/SlackKit/Sources/EventHandling.swift
+++ b/SlackKit/Sources/EventHandling.swift
@@ -1,5 +1,5 @@
 //
-// EventHandler.swift
+// EventHandling.swift
 //
 // Copyright © 2016 Peter Zignego. All rights reserved.
 //
@@ -23,34 +23,21 @@
 
 import Foundation
 
-internal class EventHandler {
-    let client: Client
-    required init(client: Client) {
-        self.client = client
-    }
-    
-    //MARK: - Initial connection
-    func connected() {
-        client.connected = true
-        
-        if let delegate = client.slackEventsDelegate {
-            delegate.clientConnected()
-        }
-    }
-    
+internal extension Client {
+
     //MARK: - Pong
     func pong(event: Event) {
-        client.pong = event.replyTo
+        pong = event.replyTo
     }
     
     //MARK: - Messages
     func messageSent(event: Event) {
-        if let reply = event.replyTo, message = client.sentMessages[NSNumber(double: reply).stringValue], channel = message.channel, ts = message.ts {
+        if let reply = event.replyTo, message = sentMessages[NSNumber(double: reply).stringValue], channel = message.channel, ts = message.ts {
             message.ts = event.ts
             message.text = event.text
-            client.channels[channel]?.messages[ts] = message
+            channels[channel]?.messages[ts] = message
             
-            if let delegate = client.messageEventsDelegate {
+            if let delegate = messageEventsDelegate {
                 delegate.messageSent(message)
             }
         }
@@ -58,9 +45,9 @@ internal class EventHandler {
     
     func messageReceived(event: Event) {
         if let channel = event.channel, message = event.message, id = channel.id, ts = message.ts {
-            client.channels[id]?.messages[ts] = message
+            channels[id]?.messages[ts] = message
             
-            if let delegate = client.messageEventsDelegate {
+            if let delegate = messageEventsDelegate {
                 delegate.messageReceived(message)
             }
         }
@@ -68,9 +55,9 @@ internal class EventHandler {
     
     func messageChanged(event: Event) {
         if let id = event.channel?.id, nested = event.nestedMessage, ts = nested.ts {
-            client.channels[id]?.messages[ts] = nested
+            channels[id]?.messages[ts] = nested
             
-            if let delegate = client.messageEventsDelegate {
+            if let delegate = messageEventsDelegate {
                 delegate.messageChanged(nested)
             }
         }
@@ -78,10 +65,10 @@ internal class EventHandler {
     
     func messageDeleted(event: Event) {
         if let id = event.channel?.id, key = event.message?.deletedTs {
-            let message = client.channels[id]?.messages[key]
-            client.channels[id]?.messages.removeValueForKey(key)
+            let message = channels[id]?.messages[key]
+            channels[id]?.messages.removeValueForKey(key)
             
-            if let delegate = client.messageEventsDelegate {
+            if let delegate = messageEventsDelegate {
                 delegate.messageDeleted(message)
             }
         }
@@ -90,11 +77,11 @@ internal class EventHandler {
     //MARK: - Channels
     func userTyping(event: Event) {
         if let channelID = event.channel?.id, userID = event.user?.id {
-            if let _ = client.channels[channelID] {
-                if (!client.channels[channelID]!.usersTyping.contains(userID)) {
-                    client.channels[channelID]?.usersTyping.append(userID)
+            if let _ = channels[channelID] {
+                if (!channels[channelID]!.usersTyping.contains(userID)) {
+                    channels[channelID]?.usersTyping.append(userID)
                     
-                    if let delegate = client.channelEventsDelegate {
+                    if let delegate = channelEventsDelegate {
                         delegate.userTyping(event.channel, user: event.user)
                     }
                 }
@@ -102,8 +89,8 @@ internal class EventHandler {
             
             let timeout = dispatch_time(DISPATCH_TIME_NOW, Int64(5.0 * Double(NSEC_PER_SEC)))
             dispatch_after(timeout, dispatch_get_main_queue()) {
-                if let index = self.client.channels[channelID]?.usersTyping.indexOf(userID) {
-                    self.client.channels[channelID]?.usersTyping.removeAtIndex(index)
+                if let index = self.channels[channelID]?.usersTyping.indexOf(userID) {
+                    self.channels[channelID]?.usersTyping.removeAtIndex(index)
                 }
             }
         }
@@ -111,9 +98,9 @@ internal class EventHandler {
     
     func channelMarked(event: Event) {
         if let channel = event.channel, id = channel.id {
-            client.channels[id]?.lastRead = event.ts
+            channels[id]?.lastRead = event.ts
             
-            if let delegate = client.channelEventsDelegate {
+            if let delegate = channelEventsDelegate {
                 delegate.channelMarked(channel, timestamp: event.ts)
             }
         }
@@ -122,9 +109,9 @@ internal class EventHandler {
     
     func channelCreated(event: Event) {
         if let channel = event.channel, id = channel.id {
-            client.channels[id] = channel
+            channels[id] = channel
             
-            if let delegate = client.channelEventsDelegate {
+            if let delegate = channelEventsDelegate {
                 delegate.channelCreated(channel)
             }
         }
@@ -132,9 +119,9 @@ internal class EventHandler {
     
     func channelDeleted(event: Event) {
         if let channel = event.channel, id = channel.id {
-            client.channels.removeValueForKey(id)
+            channels.removeValueForKey(id)
             
-            if let delegate = client.channelEventsDelegate {
+            if let delegate = channelEventsDelegate {
                 delegate.channelDeleted(channel)
             }
         }
@@ -142,20 +129,20 @@ internal class EventHandler {
     
     func channelJoined(event: Event) {
         if let channel = event.channel, id = channel.id {
-            client.channels[id] = event.channel
+            channels[id] = event.channel
             
-            if let delegate = client.channelEventsDelegate {
+            if let delegate = channelEventsDelegate {
                 delegate.channelJoined(channel)
             }
         }
     }
     
     func channelLeft(event: Event) {
-        if let channel = event.channel, id = channel.id, userID = client.authenticatedUser?.id {
-            if let index = client.channels[id]?.members?.indexOf(userID) {
-                client.channels[id]?.members?.removeAtIndex(index)
+        if let channel = event.channel, id = channel.id, userID = authenticatedUser?.id {
+            if let index = channels[id]?.members?.indexOf(userID) {
+                channels[id]?.members?.removeAtIndex(index)
                 
-                if let delegate = client.channelEventsDelegate {
+                if let delegate = channelEventsDelegate {
                     delegate.channelLeft(channel)
                 }
             }
@@ -164,9 +151,9 @@ internal class EventHandler {
     
     func channelRenamed(event: Event) {
         if let channel = event.channel, id = channel.id {
-            client.channels[id]?.name = channel.name
+            channels[id]?.name = channel.name
             
-            if let delegate = client.channelEventsDelegate {
+            if let delegate = channelEventsDelegate {
                 delegate.channelRenamed(channel)
             }
         }
@@ -174,9 +161,9 @@ internal class EventHandler {
     
     func channelArchived(event: Event, archived: Bool) {
         if let channel = event.channel, id = channel.id {
-            client.channels[id]?.isArchived = archived
+            channels[id]?.isArchived = archived
             
-            if let delegate = client.channelEventsDelegate {
+            if let delegate = channelEventsDelegate {
                 delegate.channelArchived(channel)
             }
         }
@@ -186,7 +173,7 @@ internal class EventHandler {
         if let channel = event.channel {
             //TODO: Reload chat history if there are any cached messages before latest
             
-            if let delegate = client.channelEventsDelegate {
+            if let delegate = channelEventsDelegate {
                 delegate.channelHistoryChanged(channel)
             }
         }
@@ -195,9 +182,9 @@ internal class EventHandler {
     //MARK: - Do Not Disturb
     func doNotDisturbUpdated(event: Event) {
         if let dndStatus = event.dndStatus {
-            client.authenticatedUser?.doNotDisturbStatus = dndStatus
+            authenticatedUser?.doNotDisturbStatus = dndStatus
             
-            if let delegate = client.doNotDisturbEventsDelegate {
+            if let delegate = doNotDisturbEventsDelegate {
                 delegate.doNotDisturbUpdated(dndStatus)
             }
         }
@@ -205,9 +192,9 @@ internal class EventHandler {
     
     func doNotDisturbUserUpdated(event: Event) {
         if let dndStatus = event.dndStatus, user = event.user, id = user.id {
-            client.users[id]?.doNotDisturbStatus = dndStatus
+            users[id]?.doNotDisturbStatus = dndStatus
             
-            if let delegate = client.doNotDisturbEventsDelegate {
+            if let delegate = doNotDisturbEventsDelegate {
                 delegate.doNotDisturbUserUpdated(dndStatus, user: user)
             }
         }
@@ -216,9 +203,9 @@ internal class EventHandler {
     //MARK: - IM & Group Open/Close
     func open(event: Event, open: Bool) {
         if let channel = event.channel, id = channel.id {
-            client.channels[id]?.isOpen = open
+            channels[id]?.isOpen = open
             
-            if let delegate = client.groupEventsDelegate {
+            if let delegate = groupEventsDelegate {
                 delegate.groupOpened(channel)
             }
         }
@@ -228,14 +215,14 @@ internal class EventHandler {
     func processFile(event: Event) {
         if let file = event.file, id = file.id {
             if let comment = file.initialComment, commentID = comment.id {
-                if client.files[id]?.comments[commentID] == nil {
-                    client.files[id]?.comments[commentID] = comment
+                if files[id]?.comments[commentID] == nil {
+                    files[id]?.comments[commentID] = comment
                 }
             }
             
-            client.files[id] = file
+            files[id] = file
             
-            if let delegate = client.fileEventsDelegate {
+            if let delegate = fileEventsDelegate {
                 delegate.fileProcessed(file)
             }
         }
@@ -243,9 +230,9 @@ internal class EventHandler {
     
     func filePrivate(event: Event) {
         if let file =  event.file, id = file.id {
-            client.files[id]?.isPublic = false
+            files[id]?.isPublic = false
             
-            if let delegate = client.fileEventsDelegate {
+            if let delegate = fileEventsDelegate {
                 delegate.fileMadePrivate(file)
             }
         }
@@ -253,11 +240,11 @@ internal class EventHandler {
     
     func deleteFile(event: Event) {
         if let file = event.file, id = file.id {
-            if client.files[id] != nil {
-                client.files.removeValueForKey(id)
+            if files[id] != nil {
+                files.removeValueForKey(id)
             }
             
-            if let delegate = client.fileEventsDelegate {
+            if let delegate = fileEventsDelegate {
                 delegate.fileDeleted(file)
             }
         }
@@ -265,9 +252,9 @@ internal class EventHandler {
     
     func fileCommentAdded(event: Event) {
         if let file = event.file, id = file.id, comment = event.comment, commentID = comment.id {
-            client.files[id]?.comments[commentID] = comment
+            files[id]?.comments[commentID] = comment
             
-            if let delegate = client.fileEventsDelegate {
+            if let delegate = fileEventsDelegate {
                 delegate.fileCommentAdded(file, comment: comment)
             }
         }
@@ -275,9 +262,9 @@ internal class EventHandler {
     
     func fileCommentEdited(event: Event) {
         if let file = event.file, id = file.id, comment = event.comment, commentID = comment.id {
-            client.files[id]?.comments[commentID]?.comment = comment.comment
+            files[id]?.comments[commentID]?.comment = comment.comment
             
-            if let delegate = client.fileEventsDelegate {
+            if let delegate = fileEventsDelegate {
                 delegate.fileCommentEdited(file, comment: comment)
             }
         }
@@ -285,9 +272,9 @@ internal class EventHandler {
     
     func fileCommentDeleted(event: Event) {
         if let file = event.file, id = file.id, comment = event.comment, commentID = comment.id {
-            client.files[id]?.comments.removeValueForKey(commentID)
+            files[id]?.comments.removeValueForKey(commentID)
             
-            if let delegate = client.fileEventsDelegate {
+            if let delegate = fileEventsDelegate {
                 delegate.fileCommentDeleted(file, comment: comment)
             }
         }
@@ -296,22 +283,22 @@ internal class EventHandler {
     //MARK: - Pins
     func pinAdded(event: Event) {
         if let id = event.channelID, item = event.item {
-            client.channels[id]?.pinnedItems.append(item)
+            channels[id]?.pinnedItems.append(item)
             
-            if let delegate = client.pinEventsDelegate {
-                delegate.itemPinned(item, channel: client.channels[id])
+            if let delegate = pinEventsDelegate {
+                delegate.itemPinned(item, channel: channels[id])
             }
         }
     }
     
     func pinRemoved(event: Event) {
         if let id = event.channelID {
-            if let pins = client.channels[id]?.pinnedItems.filter({$0 != event.item}) {
-                client.channels[id]?.pinnedItems = pins
+            if let pins = channels[id]?.pinnedItems.filter({$0 != event.item}) {
+                channels[id]?.pinnedItems = pins
             }
             
-            if let delegate = client.pinEventsDelegate {
-                delegate.itemUnpinned(event.item, channel: client.channels[id])
+            if let delegate = pinEventsDelegate {
+                delegate.itemUnpinned(event.item, channel: channels[id])
             }
         }
     }
@@ -330,7 +317,7 @@ internal class EventHandler {
                 break
             }
             
-            if let delegate = client.starEventsDelegate {
+            if let delegate = starEventsDelegate {
                 delegate.itemStarred(item, star: star)
             }
         }
@@ -338,21 +325,21 @@ internal class EventHandler {
     
     func starMessage(item: Item, star: Bool) {
         if let message = item.message, ts = message.ts, channel = item.channel {
-            if let _ = client.channels[channel]?.messages[ts] {
-                client.channels[channel]?.messages[ts]?.isStarred = star
+            if let _ = channels[channel]?.messages[ts] {
+                channels[channel]?.messages[ts]?.isStarred = star
             }
         }
     }
     
     func starFile(item: Item, star: Bool) {
         if let file = item.file, id = file.id {
-            client.files[id]?.isStarred = star
-            if let stars = client.files[id]?.stars {
+            files[id]?.isStarred = star
+            if let stars = files[id]?.stars {
                 if star == true {
-                    client.files[id]?.stars = stars + 1
+                    files[id]?.stars = stars + 1
                 } else {
                     if stars > 0 {
-                        client.files[id]?.stars = stars - 1
+                        files[id]?.stars = stars - 1
                     }
                 }
             }
@@ -361,7 +348,7 @@ internal class EventHandler {
     
     func starComment(item: Item) {
         if let file = item.file, id = file.id, comment = item.comment, commentID = comment.id {
-            client.files[id]?.comments[commentID] = comment
+            files[id]?.comments[commentID] = comment
         }
     }
     
@@ -371,7 +358,7 @@ internal class EventHandler {
             switch type {
             case "message":
                 if let channel = item.channel, ts = item.ts {
-                    if let message = client.channels[channel]?.messages[ts] {
+                    if let message = channels[channel]?.messages[ts] {
                         if (message.reactions[key]) == nil {
                             message.reactions[key] = Reaction(name: event.reaction, user: userID)
                         } else {
@@ -380,19 +367,19 @@ internal class EventHandler {
                     }
                 }
             case "file":
-                if let id = item.file?.id, file = client.files[id] {
+                if let id = item.file?.id, file = files[id] {
                     if file.reactions[key] == nil {
-                        client.files[id]?.reactions[key] = Reaction(name: event.reaction, user: userID)
+                        files[id]?.reactions[key] = Reaction(name: event.reaction, user: userID)
                     } else {
-                        client.files[id]?.reactions[key]?.users[userID] = userID
+                        files[id]?.reactions[key]?.users[userID] = userID
                     }
                 }
             case "file_comment":
-                if let id = item.file?.id, file = client.files[id], commentID = item.fileCommentID {
+                if let id = item.file?.id, file = files[id], commentID = item.fileCommentID {
                     if file.comments[commentID]?.reactions[key] == nil {
-                        client.files[id]?.comments[commentID]?.reactions[key] = Reaction(name: event.reaction, user: userID)
+                        files[id]?.comments[commentID]?.reactions[key] = Reaction(name: event.reaction, user: userID)
                     } else {
-                        client.files[id]?.comments[commentID]?.reactions[key]?.users[userID] = userID
+                        files[id]?.comments[commentID]?.reactions[key]?.users[userID] = userID
                     }
                 }
                 break
@@ -400,7 +387,7 @@ internal class EventHandler {
                 break
             }
             
-            if let delegate = client.reactionEventsDelegate {
+            if let delegate = reactionEventsDelegate {
                 delegate.reactionAdded(event.reaction, item: event.item, itemUser: event.itemUser)
             }
         }
@@ -411,7 +398,7 @@ internal class EventHandler {
             switch type {
             case "message":
                 if let channel = item.channel, ts = item.ts {
-                    if let message = client.channels[channel]?.messages[ts] {
+                    if let message = channels[channel]?.messages[ts] {
                         if (message.reactions[key]) != nil {
                             message.reactions[key]?.users.removeValueForKey(userID)
                         }
@@ -421,21 +408,21 @@ internal class EventHandler {
                     }
                 }
             case "file":
-                if let itemFile = item.file, id = itemFile.id, file = client.files[id] {
+                if let itemFile = item.file, id = itemFile.id, file = files[id] {
                     if file.reactions[key] != nil {
-                        client.files[id]?.reactions[key]?.users.removeValueForKey(userID)
+                        files[id]?.reactions[key]?.users.removeValueForKey(userID)
                     }
-                    if client.files[id]?.reactions[key]?.users.count == 0 {
-                        client.files[id]?.reactions.removeValueForKey(key)
+                    if files[id]?.reactions[key]?.users.count == 0 {
+                        files[id]?.reactions.removeValueForKey(key)
                     }
                 }
             case "file_comment":
-                if let id = item.file?.id, file = client.files[id], commentID = item.fileCommentID {
+                if let id = item.file?.id, file = files[id], commentID = item.fileCommentID {
                     if file.comments[commentID]?.reactions[key] != nil {
-                        client.files[id]?.comments[commentID]?.reactions[key]?.users.removeValueForKey(userID)
+                        files[id]?.comments[commentID]?.reactions[key]?.users.removeValueForKey(userID)
                     }
-                    if client.files[id]?.comments[commentID]?.reactions[key]?.users.count == 0 {
-                        client.files[id]?.comments[commentID]?.reactions.removeValueForKey(key)
+                    if files[id]?.comments[commentID]?.reactions[key]?.users.count == 0 {
+                        files[id]?.comments[commentID]?.reactions.removeValueForKey(key)
                     }
                 }
                 break
@@ -443,7 +430,7 @@ internal class EventHandler {
                 break
             }
             
-            if let delegate = client.reactionEventsDelegate {
+            if let delegate = reactionEventsDelegate {
                 delegate.reactionAdded(event.reaction, item: event.item, itemUser: event.itemUser)
             }
         }
@@ -452,9 +439,9 @@ internal class EventHandler {
     //MARK: - Preferences
     func changePreference(event: Event) {
         if let name = event.name {
-            client.authenticatedUser?.preferences?[name] = event.value
+            authenticatedUser?.preferences?[name] = event.value
             
-            if let delegate = client.slackEventsDelegate, value = event.value {
+            if let delegate = slackEventsDelegate, value = event.value {
                 delegate.preferenceChanged(name, value: value)
             }
         }
@@ -463,11 +450,11 @@ internal class EventHandler {
     //Mark: - User Change
     func userChange(event: Event) {
         if let user = event.user, id = user.id {
-            let preferences = client.users[id]?.preferences
-            client.users[id] = user
-            client.users[id]?.preferences = preferences
+            let preferences = users[id]?.preferences
+            users[id] = user
+            users[id]?.preferences = preferences
             
-            if let delegate = client.slackEventsDelegate {
+            if let delegate = slackEventsDelegate {
                 delegate.userChanged(user)
             }
         }
@@ -476,9 +463,9 @@ internal class EventHandler {
     //MARK: - User Presence
     func presenceChange(event: Event) {
         if let user = event.user, id = user.id {
-            client.users[id]?.presence = event.presence
+            users[id]?.presence = event.presence
             
-            if let delegate = client.slackEventsDelegate {
+            if let delegate = slackEventsDelegate {
                 delegate.presenceChanged(user, presence: event.presence)
             }
         }
@@ -487,9 +474,9 @@ internal class EventHandler {
     //MARK: - Team
     func teamJoin(event: Event) {
         if let user = event.user, id = user.id {
-            client.users[id] = user
+            users[id] = user
             
-            if let delegate = client.teamEventsDelegate {
+            if let delegate = teamEventsDelegate {
                 delegate.teamJoined(user)
             }
         }
@@ -497,9 +484,9 @@ internal class EventHandler {
     
     func teamPlanChange(event: Event) {
         if let plan = event.plan {
-            client.team?.plan = plan
+            team?.plan = plan
             
-            if let delegate = client.teamEventsDelegate {
+            if let delegate = teamEventsDelegate {
                 delegate.teamPlanChanged(plan)
             }
         }
@@ -507,9 +494,9 @@ internal class EventHandler {
     
     func teamPreferenceChange(event: Event) {
         if let name = event.name {
-            client.team?.prefs?[name] = event.value
+            team?.prefs?[name] = event.value
             
-            if let delegate = client.teamEventsDelegate, value = event.value {
+            if let delegate = teamEventsDelegate, value = event.value {
                 delegate.teamPreferencesChanged(name, value: value)
             }
         }
@@ -517,9 +504,9 @@ internal class EventHandler {
     
     func teamNameChange(event: Event) {
         if let name = event.name {
-            client.team?.name = name
+            team?.name = name
             
-            if let delegate = client.teamEventsDelegate {
+            if let delegate = teamEventsDelegate {
                 delegate.teamNameChanged(name)
             }
         }
@@ -527,9 +514,9 @@ internal class EventHandler {
     
     func teamDomainChange(event: Event) {
         if let domain = event.domain {
-            client.team?.domain = domain
+            team?.domain = domain
             
-            if let delegate = client.teamEventsDelegate {
+            if let delegate = teamEventsDelegate {
                 delegate.teamDomainChanged(domain)
             }
         }
@@ -537,9 +524,9 @@ internal class EventHandler {
     
     func emailDomainChange(event: Event) {
         if let domain = event.emailDomain {
-            client.team?.emailDomain = domain
+            team?.emailDomain = domain
             
-            if let delegate = client.teamEventsDelegate {
+            if let delegate = teamEventsDelegate {
                 delegate.teamEmailDomainChanged(domain)
             }
         }
@@ -548,7 +535,7 @@ internal class EventHandler {
     func emojiChanged(event: Event) {
         //TODO: Call emoji.list here
         
-        if let delegate = client.teamEventsDelegate {
+        if let delegate = teamEventsDelegate {
             delegate.teamEmojiChanged()
         }
     }
@@ -556,9 +543,9 @@ internal class EventHandler {
     //MARK: - Bots
     func bot(event: Event) {
         if let bot = event.bot, id = bot.id {
-            client.bots[id] = bot
+            bots[id] = bot
             
-            if let delegate = client.slackEventsDelegate {
+            if let delegate = slackEventsDelegate {
                 delegate.botEvent(bot)
             }
         }
@@ -567,9 +554,9 @@ internal class EventHandler {
     //MARK: - Subteams
     func subteam(event: Event) {
         if let subteam = event.subteam, id = subteam.id {
-            client.userGroups[id] = subteam
+            userGroups[id] = subteam
             
-            if let delegate = client.subteamEventsDelegate {
+            if let delegate = subteamEventsDelegate {
                 delegate.subteamEvent(subteam)
             }
         }
@@ -577,10 +564,10 @@ internal class EventHandler {
     }
     
     func subteamAddedSelf(event: Event) {
-        if let subteamID = event.subteamID, _ = client.authenticatedUser?.userGroups {
-            client.authenticatedUser?.userGroups![subteamID] = subteamID
+        if let subteamID = event.subteamID, _ = authenticatedUser?.userGroups {
+            authenticatedUser?.userGroups![subteamID] = subteamID
             
-            if let delegate = client.subteamEventsDelegate {
+            if let delegate = subteamEventsDelegate {
                 delegate.subteamSelfAdded(subteamID)
             }
         }
@@ -588,9 +575,9 @@ internal class EventHandler {
     
     func subteamRemovedSelf(event: Event) {
         if let subteamID = event.subteamID {
-            client.authenticatedUser?.userGroups?.removeValueForKey(subteamID)
+            authenticatedUser?.userGroups?.removeValueForKey(subteamID)
             
-            if let delegate = client.subteamEventsDelegate {
+            if let delegate = subteamEventsDelegate {
                 delegate.subteamSelfRemoved(subteamID)
             }
         }
@@ -598,51 +585,51 @@ internal class EventHandler {
     
     //MARK: - Team Profiles
     func teamProfileChange(event: Event) {
-        for user in client.users {
+        for user in users {
             if let fields = event.profile?.fields {
                 for key in fields.keys {
-                    client.users[user.0]?.profile?.customProfile?.fields[key]?.updateProfileField(fields[key])
+                    users[user.0]?.profile?.customProfile?.fields[key]?.updateProfileField(fields[key])
                 }
             }
         }
         
-        if let delegate = client.teamProfileEventsDelegate {
+        if let delegate = teamProfileEventsDelegate {
             delegate.teamProfileChanged(event.profile)
         }
     }
     
     func teamProfileDeleted(event: Event) {
-        for user in client.users {
+        for user in users {
             if let id = event.profile?.fields.first?.0 {
-                client.users[user.0]?.profile?.customProfile?.fields[id] = nil
+                users[user.0]?.profile?.customProfile?.fields[id] = nil
             }
         }
         
-        if let delegate = client.teamProfileEventsDelegate {
+        if let delegate = teamProfileEventsDelegate {
             delegate.teamProfileDeleted(event.profile)
         }
     }
     
     func teamProfileReordered(event: Event) {
-        for user in client.users {
+        for user in users {
             if let keys = event.profile?.fields.keys {
                 for key in keys {
-                    client.users[user.0]?.profile?.customProfile?.fields[key]?.ordering = event.profile?.fields[key]?.ordering
+                    users[user.0]?.profile?.customProfile?.fields[key]?.ordering = event.profile?.fields[key]?.ordering
                 }
             }
         }
         
-        if let delegate = client.teamProfileEventsDelegate {
+        if let delegate = teamProfileEventsDelegate {
             delegate.teamProfileReordered(event.profile)
         }
     }
     
     //MARK: - Authenticated User
     func manualPresenceChange(event: Event) {
-        client.authenticatedUser?.presence = event.presence
+        authenticatedUser?.presence = event.presence
         
-        if let delegate = client.slackEventsDelegate {
-            delegate.manualPresenceChanged(client.authenticatedUser, presence: event.presence)
+        if let delegate = slackEventsDelegate {
+            delegate.manualPresenceChanged(authenticatedUser, presence: event.presence)
         }
     }
     

--- a/SlackKit/Sources/EventHandling.swift
+++ b/SlackKit/Sources/EventHandling.swift
@@ -37,9 +37,7 @@ internal extension Client {
             message.text = event.text
             channels[channel]?.messages[ts] = message
             
-            if let delegate = messageEventsDelegate {
-                delegate.messageSent(message)
-            }
+            messageEventsDelegate?.messageSent(message)
         }
     }
     
@@ -47,9 +45,7 @@ internal extension Client {
         if let channel = event.channel, message = event.message, id = channel.id, ts = message.ts {
             channels[id]?.messages[ts] = message
             
-            if let delegate = messageEventsDelegate {
-                delegate.messageReceived(message)
-            }
+            messageEventsDelegate?.messageReceived(message)
         }
     }
     
@@ -57,9 +53,7 @@ internal extension Client {
         if let id = event.channel?.id, nested = event.nestedMessage, ts = nested.ts {
             channels[id]?.messages[ts] = nested
             
-            if let delegate = messageEventsDelegate {
-                delegate.messageChanged(nested)
-            }
+            messageEventsDelegate?.messageChanged(nested)
         }
     }
     
@@ -68,9 +62,7 @@ internal extension Client {
             let message = channels[id]?.messages[key]
             channels[id]?.messages.removeValueForKey(key)
             
-            if let delegate = messageEventsDelegate {
-                delegate.messageDeleted(message)
-            }
+            messageEventsDelegate?.messageDeleted(message)
         }
     }
     
@@ -81,9 +73,7 @@ internal extension Client {
                 if (!channels[channelID]!.usersTyping.contains(userID)) {
                     channels[channelID]?.usersTyping.append(userID)
                     
-                    if let delegate = channelEventsDelegate {
-                        delegate.userTyping(event.channel, user: event.user)
-                    }
+                    channelEventsDelegate?.userTyping(event.channel, user: event.user)
                 }
             }
             
@@ -100,9 +90,7 @@ internal extension Client {
         if let channel = event.channel, id = channel.id {
             channels[id]?.lastRead = event.ts
             
-            if let delegate = channelEventsDelegate {
-                delegate.channelMarked(channel, timestamp: event.ts)
-            }
+            channelEventsDelegate?.channelMarked(channel, timestamp: event.ts)
         }
         //TODO: Recalculate unreads
     }
@@ -111,9 +99,7 @@ internal extension Client {
         if let channel = event.channel, id = channel.id {
             channels[id] = channel
             
-            if let delegate = channelEventsDelegate {
-                delegate.channelCreated(channel)
-            }
+            channelEventsDelegate?.channelCreated(channel)
         }
     }
     
@@ -121,9 +107,7 @@ internal extension Client {
         if let channel = event.channel, id = channel.id {
             channels.removeValueForKey(id)
             
-            if let delegate = channelEventsDelegate {
-                delegate.channelDeleted(channel)
-            }
+            channelEventsDelegate?.channelDeleted(channel)
         }
     }
     
@@ -131,9 +115,7 @@ internal extension Client {
         if let channel = event.channel, id = channel.id {
             channels[id] = event.channel
             
-            if let delegate = channelEventsDelegate {
-                delegate.channelJoined(channel)
-            }
+            channelEventsDelegate?.channelJoined(channel)
         }
     }
     
@@ -142,9 +124,7 @@ internal extension Client {
             if let index = channels[id]?.members?.indexOf(userID) {
                 channels[id]?.members?.removeAtIndex(index)
                 
-                if let delegate = channelEventsDelegate {
-                    delegate.channelLeft(channel)
-                }
+                channelEventsDelegate?.channelLeft(channel)
             }
         }
     }
@@ -153,9 +133,7 @@ internal extension Client {
         if let channel = event.channel, id = channel.id {
             channels[id]?.name = channel.name
             
-            if let delegate = channelEventsDelegate {
-                delegate.channelRenamed(channel)
-            }
+            channelEventsDelegate?.channelRenamed(channel)
         }
     }
     
@@ -163,9 +141,7 @@ internal extension Client {
         if let channel = event.channel, id = channel.id {
             channels[id]?.isArchived = archived
             
-            if let delegate = channelEventsDelegate {
-                delegate.channelArchived(channel)
-            }
+            channelEventsDelegate?.channelArchived(channel)
         }
     }
     
@@ -173,9 +149,7 @@ internal extension Client {
         if let channel = event.channel {
             //TODO: Reload chat history if there are any cached messages before latest
             
-            if let delegate = channelEventsDelegate {
-                delegate.channelHistoryChanged(channel)
-            }
+            channelEventsDelegate?.channelHistoryChanged(channel)
         }
     }
     
@@ -184,9 +158,7 @@ internal extension Client {
         if let dndStatus = event.dndStatus {
             authenticatedUser?.doNotDisturbStatus = dndStatus
             
-            if let delegate = doNotDisturbEventsDelegate {
-                delegate.doNotDisturbUpdated(dndStatus)
-            }
+            doNotDisturbEventsDelegate?.doNotDisturbUpdated(dndStatus)
         }
     }
     
@@ -194,9 +166,7 @@ internal extension Client {
         if let dndStatus = event.dndStatus, user = event.user, id = user.id {
             users[id]?.doNotDisturbStatus = dndStatus
             
-            if let delegate = doNotDisturbEventsDelegate {
-                delegate.doNotDisturbUserUpdated(dndStatus, user: user)
-            }
+            doNotDisturbEventsDelegate?.doNotDisturbUserUpdated(dndStatus, user: user)
         }
     }
     
@@ -205,9 +175,7 @@ internal extension Client {
         if let channel = event.channel, id = channel.id {
             channels[id]?.isOpen = open
             
-            if let delegate = groupEventsDelegate {
-                delegate.groupOpened(channel)
-            }
+            groupEventsDelegate?.groupOpened(channel)
         }
     }
     
@@ -222,9 +190,7 @@ internal extension Client {
             
             files[id] = file
             
-            if let delegate = fileEventsDelegate {
-                delegate.fileProcessed(file)
-            }
+            fileEventsDelegate?.fileProcessed(file)
         }
     }
     
@@ -232,9 +198,7 @@ internal extension Client {
         if let file =  event.file, id = file.id {
             files[id]?.isPublic = false
             
-            if let delegate = fileEventsDelegate {
-                delegate.fileMadePrivate(file)
-            }
+            fileEventsDelegate?.fileMadePrivate(file)
         }
     }
     
@@ -244,9 +208,7 @@ internal extension Client {
                 files.removeValueForKey(id)
             }
             
-            if let delegate = fileEventsDelegate {
-                delegate.fileDeleted(file)
-            }
+            fileEventsDelegate?.fileDeleted(file)
         }
     }
     
@@ -254,9 +216,7 @@ internal extension Client {
         if let file = event.file, id = file.id, comment = event.comment, commentID = comment.id {
             files[id]?.comments[commentID] = comment
             
-            if let delegate = fileEventsDelegate {
-                delegate.fileCommentAdded(file, comment: comment)
-            }
+            fileEventsDelegate?.fileCommentAdded(file, comment: comment)
         }
     }
     
@@ -264,9 +224,7 @@ internal extension Client {
         if let file = event.file, id = file.id, comment = event.comment, commentID = comment.id {
             files[id]?.comments[commentID]?.comment = comment.comment
             
-            if let delegate = fileEventsDelegate {
-                delegate.fileCommentEdited(file, comment: comment)
-            }
+            fileEventsDelegate?.fileCommentEdited(file, comment: comment)
         }
     }
     
@@ -274,9 +232,7 @@ internal extension Client {
         if let file = event.file, id = file.id, comment = event.comment, commentID = comment.id {
             files[id]?.comments.removeValueForKey(commentID)
             
-            if let delegate = fileEventsDelegate {
-                delegate.fileCommentDeleted(file, comment: comment)
-            }
+            fileEventsDelegate?.fileCommentDeleted(file, comment: comment)
         }
     }
     
@@ -285,9 +241,7 @@ internal extension Client {
         if let id = event.channelID, item = event.item {
             channels[id]?.pinnedItems.append(item)
             
-            if let delegate = pinEventsDelegate {
-                delegate.itemPinned(item, channel: channels[id])
-            }
+            pinEventsDelegate?.itemPinned(item, channel: channels[id])
         }
     }
     
@@ -297,9 +251,7 @@ internal extension Client {
                 channels[id]?.pinnedItems = pins
             }
             
-            if let delegate = pinEventsDelegate {
-                delegate.itemUnpinned(event.item, channel: channels[id])
-            }
+            pinEventsDelegate?.itemUnpinned(event.item, channel: channels[id])
         }
     }
     
@@ -317,9 +269,7 @@ internal extension Client {
                 break
             }
             
-            if let delegate = starEventsDelegate {
-                delegate.itemStarred(item, star: star)
-            }
+            starEventsDelegate?.itemStarred(item, star: star)
         }
     }
     
@@ -387,9 +337,7 @@ internal extension Client {
                 break
             }
             
-            if let delegate = reactionEventsDelegate {
-                delegate.reactionAdded(event.reaction, item: event.item, itemUser: event.itemUser)
-            }
+            reactionEventsDelegate?.reactionAdded(event.reaction, item: event.item, itemUser: event.itemUser)
         }
     }
     
@@ -430,9 +378,7 @@ internal extension Client {
                 break
             }
             
-            if let delegate = reactionEventsDelegate {
-                delegate.reactionAdded(event.reaction, item: event.item, itemUser: event.itemUser)
-            }
+            reactionEventsDelegate?.reactionAdded(event.reaction, item: event.item, itemUser: event.itemUser)
         }
     }
     
@@ -441,8 +387,8 @@ internal extension Client {
         if let name = event.name {
             authenticatedUser?.preferences?[name] = event.value
             
-            if let delegate = slackEventsDelegate, value = event.value {
-                delegate.preferenceChanged(name, value: value)
+            if let value = event.value {
+                slackEventsDelegate?.preferenceChanged(name, value: value)
             }
         }
     }
@@ -454,9 +400,7 @@ internal extension Client {
             users[id] = user
             users[id]?.preferences = preferences
             
-            if let delegate = slackEventsDelegate {
-                delegate.userChanged(user)
-            }
+            slackEventsDelegate?.userChanged(user)
         }
     }
     
@@ -465,9 +409,7 @@ internal extension Client {
         if let user = event.user, id = user.id {
             users[id]?.presence = event.presence
             
-            if let delegate = slackEventsDelegate {
-                delegate.presenceChanged(user, presence: event.presence)
-            }
+            slackEventsDelegate?.presenceChanged(user, presence: event.presence)
         }
     }
     
@@ -476,9 +418,7 @@ internal extension Client {
         if let user = event.user, id = user.id {
             users[id] = user
             
-            if let delegate = teamEventsDelegate {
-                delegate.teamJoined(user)
-            }
+            teamEventsDelegate?.teamJoined(user)
         }
     }
     
@@ -486,9 +426,7 @@ internal extension Client {
         if let plan = event.plan {
             team?.plan = plan
             
-            if let delegate = teamEventsDelegate {
-                delegate.teamPlanChanged(plan)
-            }
+            teamEventsDelegate?.teamPlanChanged(plan)
         }
     }
     
@@ -496,8 +434,8 @@ internal extension Client {
         if let name = event.name {
             team?.prefs?[name] = event.value
             
-            if let delegate = teamEventsDelegate, value = event.value {
-                delegate.teamPreferencesChanged(name, value: value)
+            if let value = event.value {
+                teamEventsDelegate?.teamPreferencesChanged(name, value: value)
             }
         }
     }
@@ -506,9 +444,7 @@ internal extension Client {
         if let name = event.name {
             team?.name = name
             
-            if let delegate = teamEventsDelegate {
-                delegate.teamNameChanged(name)
-            }
+            teamEventsDelegate?.teamNameChanged(name)
         }
     }
     
@@ -516,9 +452,7 @@ internal extension Client {
         if let domain = event.domain {
             team?.domain = domain
             
-            if let delegate = teamEventsDelegate {
-                delegate.teamDomainChanged(domain)
-            }
+            teamEventsDelegate?.teamDomainChanged(domain)
         }
     }
     
@@ -526,18 +460,14 @@ internal extension Client {
         if let domain = event.emailDomain {
             team?.emailDomain = domain
             
-            if let delegate = teamEventsDelegate {
-                delegate.teamEmailDomainChanged(domain)
-            }
+            teamEventsDelegate?.teamEmailDomainChanged(domain)
         }
     }
     
     func emojiChanged(event: Event) {
         //TODO: Call emoji.list here
         
-        if let delegate = teamEventsDelegate {
-            delegate.teamEmojiChanged()
-        }
+        teamEventsDelegate?.teamEmojiChanged()
     }
     
     //MARK: - Bots
@@ -545,9 +475,7 @@ internal extension Client {
         if let bot = event.bot, id = bot.id {
             bots[id] = bot
             
-            if let delegate = slackEventsDelegate {
-                delegate.botEvent(bot)
-            }
+            slackEventsDelegate?.botEvent(bot)
         }
     }
     
@@ -556,9 +484,7 @@ internal extension Client {
         if let subteam = event.subteam, id = subteam.id {
             userGroups[id] = subteam
             
-            if let delegate = subteamEventsDelegate {
-                delegate.subteamEvent(subteam)
-            }
+            subteamEventsDelegate?.subteamEvent(subteam)
         }
         
     }
@@ -567,9 +493,7 @@ internal extension Client {
         if let subteamID = event.subteamID, _ = authenticatedUser?.userGroups {
             authenticatedUser?.userGroups![subteamID] = subteamID
             
-            if let delegate = subteamEventsDelegate {
-                delegate.subteamSelfAdded(subteamID)
-            }
+            subteamEventsDelegate?.subteamSelfAdded(subteamID)
         }
     }
     
@@ -577,9 +501,7 @@ internal extension Client {
         if let subteamID = event.subteamID {
             authenticatedUser?.userGroups?.removeValueForKey(subteamID)
             
-            if let delegate = subteamEventsDelegate {
-                delegate.subteamSelfRemoved(subteamID)
-            }
+            subteamEventsDelegate?.subteamSelfRemoved(subteamID)
         }
     }
     
@@ -593,9 +515,7 @@ internal extension Client {
             }
         }
         
-        if let delegate = teamProfileEventsDelegate {
-            delegate.teamProfileChanged(event.profile)
-        }
+        teamProfileEventsDelegate?.teamProfileChanged(event.profile)
     }
     
     func teamProfileDeleted(event: Event) {
@@ -605,9 +525,7 @@ internal extension Client {
             }
         }
         
-        if let delegate = teamProfileEventsDelegate {
-            delegate.teamProfileDeleted(event.profile)
-        }
+        teamProfileEventsDelegate?.teamProfileDeleted(event.profile)
     }
     
     func teamProfileReordered(event: Event) {
@@ -619,18 +537,14 @@ internal extension Client {
             }
         }
         
-        if let delegate = teamProfileEventsDelegate {
-            delegate.teamProfileReordered(event.profile)
-        }
+        teamProfileEventsDelegate?.teamProfileReordered(event.profile)
     }
     
     //MARK: - Authenticated User
     func manualPresenceChange(event: Event) {
         authenticatedUser?.presence = event.presence
         
-        if let delegate = slackEventsDelegate {
-            delegate.manualPresenceChanged(authenticatedUser, presence: event.presence)
-        }
+        slackEventsDelegate?.manualPresenceChanged(authenticatedUser, presence: event.presence)
     }
     
 }

--- a/SlackKit/Sources/Extensions.swift
+++ b/SlackKit/Sources/Extensions.swift
@@ -1,0 +1,65 @@
+//
+// Extensions.swift
+//
+// Copyright © 2016 Peter Zignego. All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+import Foundation
+
+public enum AttachmentColor: String {
+    case Good = "good"
+    case Warning = "warning"
+    case Danger = "danger"
+}
+
+public extension NSDate {
+
+    func slackTimestamp() -> Double {
+        return NSNumber(double: timeIntervalSince1970).doubleValue
+    }
+    
+}
+
+internal extension String {
+    
+    func slackFormatEscaping() -> String {
+        var escapedString = stringByReplacingOccurrencesOfString("&", withString: "&amp;")
+        escapedString = stringByReplacingOccurrencesOfString("<", withString: "&lt;")
+        escapedString = stringByReplacingOccurrencesOfString(">", withString: "&gt;")
+        return escapedString
+    }
+
+}
+
+internal extension Array {
+
+    func objectArrayFromDictionaryArray<T>(intializer:([String: AnyObject])->T?) -> [T] {
+        var returnValue = [T]()
+        for object in self {
+            if let dictionary = object as? [String: AnyObject] {
+                if let value = intializer(dictionary) {
+                    returnValue.append(value)
+                }
+            }
+        }
+        return returnValue
+    }
+    
+}


### PR DESCRIPTION
Hi,
I noticed that delegates were held strongly, and also `Client` held `EventDispatcher` (which held client too, and also `EventHandler` which did the same). I believe circular dependencies were created. 
I changed `EventDispatcher` and `EventHandler` to be internal extensions of `Client`, because it looked like feature envy. 

Also, created `Client+Utilities` and `Extensions`, by splitting `ClientExtensions`. And removed unneeded `if let delegate = someDelegate` lines.

Looks like a lot of changes, but really it is not 😄 
