### PR TITLE
1.1.1

### DIFF
--- a/SlackKit.podspec
+++ b/SlackKit.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = "SlackKit"
-  s.version          = "1.1.0"
+  s.version          = "1.1.1"
   s.summary          = "a Slack client library for OS X, iOS, and tvOS written in Swift"
   s.homepage         = "https://github.com/pvzig/SlackKit"
   s.license          = 'MIT'

--- a/SlackKit/Sources/Attachment.swift
+++ b/SlackKit/Sources/Attachment.swift
@@ -37,6 +37,9 @@ public struct Attachment {
     public let fields: [AttachmentField]?
     public let imageURL: String?
     public let thumbURL: String?
+    public let footer: String?
+    public let footerIcon: String?
+    public let ts: Int?
 
     internal init(attachment: [String: AnyObject]?) {
         fallback = attachment?["fallback"] as? String
@@ -50,10 +53,13 @@ public struct Attachment {
         text = attachment?["text"] as? String
         imageURL = attachment?["image_url"] as? String
         thumbURL = attachment?["thumb_url"] as? String
+        footer = attachment?["footer"] as? String
+        footerIcon = attachment?["footer_icon"] as? String
+        ts = attachment?["ts"] as? Int
         fields = (attachment?["fields"] as? [[String: AnyObject]])?.map { AttachmentField(field: $0) }
     }
     
-    public init(fallback: String, title:String, colorHex: String? = nil, pretext: String? = nil, authorName: String? = nil, authorLink: String? = nil, authorIcon: String? = nil, titleLink: String? = nil, text: String? = nil, fields: [AttachmentField]? = nil, imageURL: String? = nil, thumbURL: String? = nil) {
+    public init(fallback: String, title:String, colorHex: String? = nil, pretext: String? = nil, authorName: String? = nil, authorLink: String? = nil, authorIcon: String? = nil, titleLink: String? = nil, text: String? = nil, fields: [AttachmentField]? = nil, imageURL: String? = nil, thumbURL: String? = nil, footer: String? = nil, footerIcon:String? = nil, ts:Int? = nil) {
         self.fallback = fallback
         self.color = colorHex
         self.pretext = pretext
@@ -66,6 +72,9 @@ public struct Attachment {
         self.fields = fields
         self.imageURL = imageURL
         self.thumbURL = thumbURL
+        self.footer = footer
+        self.footerIcon = footerIcon
+        self.ts = ts
     }
     
     internal func dictionary() -> [String: AnyObject] {
@@ -82,6 +91,9 @@ public struct Attachment {
         attachment["fields"] = fieldJSONArray(fields)
         attachment["image_url"] = imageURL
         attachment["thumb_url"] = thumbURL
+        attachment["footer"] = footer
+        attachment["footer_icon"] = footerIcon
+        attachment["ts"] = ts
         return attachment
     }
     

--- a/SlackKit/Supporting Files/Info-iOS.plist
+++ b/SlackKit/Supporting Files/Info-iOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/SlackKit/Supporting Files/Info-tvOS.plist
+++ b/SlackKit/Supporting Files/Info-tvOS.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/SlackKit/Supporting Files/Info.plist
+++ b/SlackKit/Supporting Files/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.0</string>
+	<string>1.1.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>


### PR DESCRIPTION
- Update Attachment type to add `footer`, `footer_image`, and `ts` properties: https://api.slack.com/docs/attachments
