### PR TITLE
Remove curly quotes from Carthage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ pod install
 
 Add SlackKit to your Cartfile:
 ```
-github “pvzig/SlackKit” ~> 1.0
+github "pvzig/SlackKit" ~> 1.0
 ```
 and run
 ```


### PR DESCRIPTION
Attempted to copy-paste the `Cartfile` line, but it had curly quotes -  removing those so that it works without manual editing.
