### PR TITLE
Make the following Chanel setters public 'unreadCountDisplay', 'unrea…

### DIFF
--- a/SlackKit/Sources/Channel.swift
+++ b/SlackKit/Sources/Channel.swift
@@ -38,10 +38,10 @@ public struct Channel {
     internal(set) public var topic: Topic?
     internal(set) public var purpose: Topic?
     internal(set) public var isMember: Bool?
-    internal(set) public var lastRead: String?
+    public var lastRead: String?
     internal(set) public var latest: Message?
-    internal(set) public var unread: Int?
-    internal(set) public var unreadCountDisplay: Int?
+    public var unread: Int?
+    public var unreadCountDisplay: Int?
     internal(set) public var hasPins: Bool?
     internal(set) public var members: [String]?
     // Client use


### PR DESCRIPTION
…d', and 'lastRead'

I was trying to increment unread display count for a channel after receiving a new message from the RTM  api. Unfortunately, I ran into an issue for an `IM` which does not have an `info` web api similar to `channels` and `groups`. So in order to retrieve the unread count i would have to make an `im.open` call to retrieve the count ls mentioned here: https://api.slack.com/methods/im.open . Note that `im.open` doesn't provide a full payload of the `im` channel w/ the state info. So allowing the above mentioned setters to be public allows apps/programs to accordingly set/retrieve those properties as they wish.
