### PR TITLE
Add MissingScope

### DIFF
--- a/SlackKit/Sources/SlackError.swift
+++ b/SlackKit/Sources/SlackError.swift
@@ -73,6 +73,7 @@ public enum SlackError: String, ErrorType {
     case MigrationInProgress = "migration_in_progress"
     case MissingDuration = "missing_duration"
     case MissingPostType = "missing_post_type"
+    case MissingScope = "missing_scope"
     case NameTaken = "name_taken"
     case NoChannel = "no_channel"
     case NoComment = "no_comment"


### PR DESCRIPTION
This PR fixes error handling for `missing_scope`.
When required scope is missing, SlackKit methods throw `UnknownError`.
But json response from Slack api server contains `error` key and `"missing_scope"` message.
`"missing_scope"` was not available in `SlackError`, so it was very hard to find why `UnknownError` has occurred.
