### PR TITLE
Added EventType: "desktop_notification"

### DIFF
--- a/Sources/SlackKit/Client+EventDispatching.swift
+++ b/Sources/SlackKit/Client+EventDispatching.swift
@@ -152,6 +152,9 @@ internal extension Client {
             subteamAddedSelf(event)
         case .subteamSelfRemoved:
             subteamRemovedSelf(event)
+        case .desktopNotification:
+            // implement if needed.
+            break
         case .error:
             print("Error: \(event)")
         }

--- a/Sources/SlackKit/Model/Event.swift
+++ b/Sources/SlackKit/Model/Event.swift
@@ -91,6 +91,7 @@ internal enum EventType: String {
     case subteamUpdated = "subteam_updated"
     case subteamSelfAdded = "subteam_self_added"
     case subteamSelfRemoved = "subteam_self_removed"
+    case desktopNotification = "desktop_notification"
     case ok = "ok"
     case error = "error"
 }


### PR DESCRIPTION
- Add `EventType` "desktop_notification".

**SlackKit** currently output error log when received as below:

```
{
  "content": "user: @bot abcdef",
  "event_ts": 1484119301.624465,
  "launchUri": "slack://channel?id=xxxxx&message=1484119301000012&team=xxxxx",
  "subtitle": "#xxxxx",
  "ssbFilename": "knock_brush.mp3",
  "title": "xxxxx",
  "channel": "xxxxx",
  "avatarImage": "https://avatars.slack-edge.com/xxxxx.png",
  "type": "desktop_notification",
  "imageUri": null,
  "msg": 1484119301.000012
}
```

then output log: 

```bash
Error: SlackKit.Event
```