### PR TITLE
OAuth: scopes must be supplied

### DIFF
--- a/Sources/SlackKit/OAuthServer.swift
+++ b/Sources/SlackKit/OAuthServer.swift
@@ -80,7 +80,10 @@ public struct OAuthServer {
     
     private func oauthURLRequest(_ authorize: AuthorizeRequest) -> URLRequest? {
         var components = URLComponents(string: "\(oauthURL)")
-        components?.queryItems = [URLQueryItem(name: "client_id", value: "\(authorize.clientID)")]
+        components?.queryItems = [
+            URLQueryItem(name: "client_id", value: "\(authorize.clientID)"),
+            URLQueryItem(name: "scope", value: "\(authorize.scope)"),
+        ]
         guard let url = components?.url else {
             return nil
         }


### PR DESCRIPTION
Slack API spec requires the "scope" parameter when requesting authorization code. Without it a token cannot be obtained as the initial request fails with an error.

The change necessary to fix the failure is small as `Scope` and `AuthorizeRequest` do all of the heavy-lifting already. Not sure why scopes were omitted in `oauthURLRequest`.