### PR TITLE
Adapt swift 3.1 changes and fix warnings

### DIFF
--- a/Package.pins
+++ b/Package.pins
@@ -1,0 +1,18 @@
+{
+  "autoPin": true,
+  "pins": [
+    {
+      "package": "Starscream",
+      "reason": null,
+      "repositoryURL": "https://github.com/daltoniam/Starscream",
+      "version": "2.0.4"
+    },
+    {
+      "package": "Swifter",
+      "reason": null,
+      "repositoryURL": "https://github.com/httpswift/swifter",
+      "version": "1.3.3"
+    }
+  ],
+  "version": 1
+}

--- a/Sources/SlackKit/NetworkInterface.swift
+++ b/Sources/SlackKit/NetworkInterface.swift
@@ -82,8 +82,8 @@ internal struct NetworkInterface {
         let contentType = "multipart/form-data; boundary=" + boundaryConstant
         let boundaryStart = "--\(boundaryConstant)\r\n"
         let boundaryEnd = "--\(boundaryConstant)--\r\n"
-        let contentDispositionString = "Content-Disposition: form-data; name=\"file\"; filename=\"\(parameters["filename"])\"\r\n"
-        let contentTypeString = "Content-Type: \(parameters["filetype"])\r\n\r\n"
+        let contentDispositionString = "Content-Disposition: form-data; name=\"file\"; filename=\"\(parameters["filename"] as? String ?? "")\"\r\n"
+        let contentTypeString = "Content-Type: \(parameters["filetype"] as? String ?? "")\r\n\r\n"
         
         var requestBodyData: Data = Data()
         requestBodyData.append(boundaryStart.data(using: String.Encoding.utf8)!)


### PR DESCRIPTION
https://swift.org/blog/swift-3-1-released/  `Version pinning` for the pin file.

```      01 Compile Swift Module 'SlackKit' (45 sources)
      01 /Users/xcodeserver/Develop/grabtaxi/osx-server/releases/20170330062232/.build/checkouts/SlackKit.git--7299406652047019113/Sources/SlackKit/NetworkInterface.swift:85:100: warning: string interpolation produces …
      01         let contentDispositionString = "Content-Disposition: form-data; name=\"file\"; filename=\"\(parameters["filename"])\"\r\n"
      01                                                                                                    ^~~~~~~~~~~~~~~~~~~~~~~~
      01 /Users/xcodeserver/Develop/grabtaxi/osx-server/releases/20170330062232/.build/checkouts/SlackKit.git--7299406652047019113/Sources/SlackKit/NetworkInterface.swift:85:111: note: use 'String(describing:)' to sile…
      01         let contentDispositionString = "Content-Disposition: form-data; name=\"file\"; filename=\"\(parameters["filename"])\"\r\n"
      01                                                                                                    ~~~~~~~~~~~^~~~~~~~~~~~~
      01                                                                                                     String(describing:    )
      01 /Users/xcodeserver/Develop/grabtaxi/osx-server/releases/20170330062232/.build/checkouts/SlackKit.git--7299406652047019113/Sources/SlackKit/NetworkInterface.swift:85:111: note: provide a default value to avoid …
      01         let contentDispositionString = "Content-Disposition: form-data; name=\"file\"; filename=\"\(parameters["filename"])\"\r\n"
      01                                                                                                    ~~~~~~~~~~~^~~~~~~~~~~~~
      01                                                                                                                            ?? <#default value#>
      01 /Users/xcodeserver/Develop/grabtaxi/osx-server/releases/20170330062232/.build/checkouts/SlackKit.git--7299406652047019113/Sources/SlackKit/NetworkInterface.swift:86:49: warning: string interpolation produces a…
      01         let contentTypeString = "Content-Type: \(parameters["filetype"])\r\n\r\n"
      01                                                 ^~~~~~~~~~~~~~~~~~~~~~~~
      01 /Users/xcodeserver/Develop/grabtaxi/osx-server/releases/20170330062232/.build/checkouts/SlackKit.git--7299406652047019113/Sources/SlackKit/NetworkInterface.swift:86:60: note: use 'String(describing:)' to silen…
      01         let contentTypeString = "Content-Type: \(parameters["filetype"])\r\n\r\n"
      01                                                 ~~~~~~~~~~~^~~~~~~~~~~~~
      01                                                  String(describing:    )
      01 /Users/xcodeserver/Develop/grabtaxi/osx-server/releases/20170330062232/.build/checkouts/SlackKit.git--7299406652047019113/Sources/SlackKit/NetworkInterface.swift:86:60: note: provide a default value to avoid t…
      01         let contentTypeString = "Content-Type: \(parameters["filetype"])\r\n\r\n"
      01                                                 ~~~~~~~~~~~^~~~~~~~~~~~~
      01                                                                         ?? <#default value#>```
for the warnings.