### PR TITLE
Add support for the `thread_ts` parameter used to indicate and track threaded conversations

### DIFF
--- a/Sources/SlackKit/Model/Message.swift
+++ b/Sources/SlackKit/Model/Message.swift
@@ -26,6 +26,7 @@ public final class Message: Equatable {
     public let type = "message"
     public let subtype: String?
     internal(set) public var ts: String?
+    internal(set) public var threadTs: String?
     public let user: String?
     public let channel: String?
     internal(set) public var hidden: Bool?
@@ -54,6 +55,7 @@ public final class Message: Equatable {
     public init(dictionary: [String: Any]?) {
         subtype = dictionary?["subtype"] as? String
         ts = dictionary?["ts"] as? String
+        threadTs = dictionary?["thread_ts"] as? String
         user = dictionary?["user"] as? String
         channel = dictionary?["channel"] as? String
         hidden = dictionary?["hidden"] as? Bool
@@ -82,6 +84,7 @@ public final class Message: Equatable {
     
     internal init(ts:String?) {
         self.ts = ts
+        self.threadTs = ts
         subtype = nil
         user = nil
         channel = nil
@@ -96,6 +99,6 @@ public final class Message: Equatable {
     }
     
     public static func ==(lhs: Message, rhs: Message) -> Bool {
-        return lhs.ts == rhs.ts && lhs.user == rhs.user && lhs.text == rhs.text
+        return lhs.ts == rhs.ts && lhs.threadTs == rhs.threadTs && lhs.user == rhs.user && lhs.text == rhs.text
     }
 }

--- a/Sources/SlackKit/WebAPI.swift
+++ b/Sources/SlackKit/WebAPI.swift
@@ -220,6 +220,15 @@ public final class WebAPI {
         }
     }
     
+    public func sendThreadedMessage(channel: String, thread: String, text: String, username: String? = nil, asUser: Bool? = nil, parse: ParseMode? = nil, linkNames: Bool? = nil, attachments: [Attachment?]? = nil, unfurlLinks: Bool? = nil, unfurlMedia: Bool? = nil, iconURL: String? = nil, iconEmoji: String? = nil, success: (((ts: String?, channel: String?))->Void)?, failure: FailureClosure?) {
+        let parameters: [String: Any?] = ["token": token, "channel": channel, "thread_ts": thread, "text": text.slackFormatEscaping, "as_user": asUser, "parse": parse?.rawValue, "link_names": linkNames, "unfurl_links": unfurlLinks, "unfurlMedia": unfurlMedia, "username": username, "icon_url": iconURL, "icon_emoji": iconEmoji, "attachments": encodeAttachments(attachments)]
+        networkInterface.request(.chatPostMessage, parameters: parameters, successClosure: {(response) in
+            success?((ts: response["ts"] as? String, response["channel"] as? String))
+        }) {(error) in
+            failure?(error)
+        }
+    }
+
     public func sendMeMessage(channel: String, text: String, success: (((ts: String?, channel: String?))->Void)?, failure: FailureClosure?) {
         let parameters: [String: Any?] = ["token": token, "channel": channel, "text": text.slackFormatEscaping]
         networkInterface.request(.chatMeMessage, parameters: parameters, successClosure: {(response) in


### PR DESCRIPTION
This pull request adds support for the new [message `thread_ts` parameter](https://api.slack.com/docs/message-threading) that can be inspected to determine whether or not a message is part of a threaded conversation.