### PR TITLE
Multiple Workspace Support

### DIFF
--- a/SlackKit.xcodeproj/project.pbxproj
+++ b/SlackKit.xcodeproj/project.pbxproj
@@ -31,6 +31,9 @@
 		26D1C51E1EE476DD00C95954 /* SKWebAPI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26D1C5171EE476DD00C95954 /* SKWebAPI.framework */; };
 		26D1C51F1EE476DD00C95954 /* Starscream.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26D1C5181EE476DD00C95954 /* Starscream.framework */; };
 		26D1C5201EE476DD00C95954 /* Swifter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 26D1C5191EE476DD00C95954 /* Swifter.framework */; };
+		627B38152016A0B50029FDC1 /* ClientConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627B38142016A0B50029FDC1 /* ClientConnection.swift */; };
+		627B38162016A0B50029FDC1 /* ClientConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627B38142016A0B50029FDC1 /* ClientConnection.swift */; };
+		627B38172016A0B50029FDC1 /* ClientConnection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 627B38142016A0B50029FDC1 /* ClientConnection.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -60,6 +63,7 @@
 		26D1C5171EE476DD00C95954 /* SKWebAPI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SKWebAPI.framework; path = Carthage/Build/tvOS/SKWebAPI.framework; sourceTree = "<group>"; };
 		26D1C5181EE476DD00C95954 /* Starscream.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Starscream.framework; path = Carthage/Build/tvOS/Starscream.framework; sourceTree = "<group>"; };
 		26D1C5191EE476DD00C95954 /* Swifter.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Swifter.framework; path = Carthage/Build/tvOS/Swifter.framework; sourceTree = "<group>"; };
+		627B38142016A0B50029FDC1 /* ClientConnection.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ClientConnection.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -112,6 +116,7 @@
 			isa = PBXGroup;
 			children = (
 				266687041E95CB9F00777D94 /* SlackKit.swift */,
+				627B38142016A0B50029FDC1 /* ClientConnection.swift */,
 			);
 			path = Sources;
 			sourceTree = SOURCE_ROOT;
@@ -379,6 +384,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				627B38152016A0B50029FDC1 /* ClientConnection.swift in Sources */,
 				266687051E95CB9F00777D94 /* SlackKit.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -387,6 +393,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				627B38162016A0B50029FDC1 /* ClientConnection.swift in Sources */,
 				266687061E95CB9F00777D94 /* SlackKit.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -395,6 +402,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				627B38172016A0B50029FDC1 /* ClientConnection.swift in Sources */,
 				266687071E95CB9F00777D94 /* SlackKit.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Sources/ClientConnection.swift
+++ b/Sources/ClientConnection.swift
@@ -1,0 +1,20 @@
+//
+//  ClientConnection.swift
+//  SlackKit
+//
+//  Created by Emory Dunn on 12/28/17.
+//
+
+import Foundation
+
+public class ClientConnection {
+    public var client: Client?
+    public var rtm: SKRTMAPI?
+    public var webAPI: WebAPI?
+    
+    public init(client: Client?, rtm: SKRTMAPI?, webAPI: WebAPI?) {
+        self.client = client
+        self.rtm = rtm
+        self.webAPI = webAPI
+    }
+}

--- a/Sources/SlackKit.swift
+++ b/Sources/SlackKit.swift
@@ -28,27 +28,12 @@ import Foundation
 @_exported import SKServer
 @_exported import SKWebAPI
 
-public class ClientConnection {
-    public var client: Client?
-    public var rtm: SKRTMAPI?
-    public var webAPI: WebAPI?
-    
-    public init(client: Client?, rtm: SKRTMAPI?, webAPI: WebAPI?) {
-        self.client = client
-        self.rtm = rtm
-        self.webAPI = webAPI
-    }
-    
-}
-
 public final class SlackKit: RTMAdapter {
 
     public typealias EventClosure = (Event, ClientConnection?) -> Void
     internal typealias TypedEvent = (EventType, EventClosure)
     internal var callbacks = [TypedEvent]()
-    internal(set) public var rtm: SKRTMAPI?
     internal(set) public var server: SKServer?
-    internal(set) public var webAPI: WebAPI?
     internal(set) public var clients: [String: ClientConnection] = [:]
 
     public init() {}
@@ -78,10 +63,6 @@ public final class SlackKit: RTMAdapter {
             clients[token] = ClientConnection(client: client, rtm: rtm, webAPI: nil)
         }
         clients[token]?.rtm?.connect()
-//        let clientConnection = ClientConnection(client: client, rtm: rtm, webAPI: nil)
-        
-//        clients[token] = clientConnection
-//        self.rtm?.connect()
     }
 
     public func addServer(_ server: SlackKitServer? = nil, responder: SlackKitResponder? = nil, oauth: OAuthConfig? = nil) {
@@ -97,17 +78,11 @@ public final class SlackKit: RTMAdapter {
         let oauth = OAuthMiddleware(config: config) { authorization in
             // User
             if let token = authorization.accessToken {
-//                self.webAPI = WebAPI(token: token)
                 self.addWebAPIAccessWithToken(token)
             }
             // Bot User
             if let token = authorization.bot?.botToken {
                 self.addRTMBotWithAPIToken(token)
-//                self.webAPI = WebAPI(token: token)
-//                self.rtm = SKRTMAPI(withAPIToken: token, options: RTMOptions(), rtm: nil)
-//                self.rtm?.adapter = self
-//                self.clients[token] = Client()
-//                self.rtm?.connect()
             }
         }
         return RequestRoute(path: "/oauth", middleware: oauth)

--- a/Sources/SlackKit.swift
+++ b/Sources/SlackKit.swift
@@ -28,20 +28,39 @@ import Foundation
 @_exported import SKServer
 @_exported import SKWebAPI
 
+public class ClientConnection {
+    public var client: Client?
+    public var rtm: SKRTMAPI?
+    public var webAPI: WebAPI?
+    
+    public init(client: Client?, rtm: SKRTMAPI?, webAPI: WebAPI?) {
+        self.client = client
+        self.rtm = rtm
+        self.webAPI = webAPI
+    }
+    
+}
+
 public final class SlackKit: RTMAdapter {
 
-    public typealias EventClosure = (Event, Client?) -> Void
+    public typealias EventClosure = (Event, ClientConnection?) -> Void
     internal typealias TypedEvent = (EventType, EventClosure)
     internal var callbacks = [TypedEvent]()
     internal(set) public var rtm: SKRTMAPI?
     internal(set) public var server: SKServer?
     internal(set) public var webAPI: WebAPI?
-    internal(set) public var clients: [String: Client] = [:]
+    internal(set) public var clients: [String: ClientConnection] = [:]
 
     public init() {}
 
     public func addWebAPIAccessWithToken(_ token: String) {
-        self.webAPI = WebAPI(token: token)
+        let webAPI = WebAPI(token: token)
+        if let clientConnection = clients[token] {
+            clientConnection.webAPI = webAPI
+        } else {
+            clients[token] = ClientConnection(client: nil, rtm: nil, webAPI: webAPI)
+        }
+        
     }
 
     public func addRTMBotWithAPIToken(
@@ -50,10 +69,19 @@ public final class SlackKit: RTMAdapter {
         options: RTMOptions = RTMOptions(),
         rtm: RTMWebSocket? = nil
     ) {
-        self.rtm = SKRTMAPI(withAPIToken: token, options: options, rtm: rtm)
-        self.rtm?.adapter = self
-        clients[token] = client
-        self.rtm?.connect()
+        let rtm = SKRTMAPI(withAPIToken: token, options: options, rtm: rtm)
+        rtm.adapter = self
+        
+        if let clientConnection = clients[token] {
+            clientConnection.rtm = rtm
+        } else {
+            clients[token] = ClientConnection(client: client, rtm: rtm, webAPI: nil)
+        }
+        clients[token]?.rtm?.connect()
+//        let clientConnection = ClientConnection(client: client, rtm: rtm, webAPI: nil)
+        
+//        clients[token] = clientConnection
+//        self.rtm?.connect()
     }
 
     public func addServer(_ server: SlackKitServer? = nil, responder: SlackKitResponder? = nil, oauth: OAuthConfig? = nil) {
@@ -69,15 +97,17 @@ public final class SlackKit: RTMAdapter {
         let oauth = OAuthMiddleware(config: config) { authorization in
             // User
             if let token = authorization.accessToken {
-                self.webAPI = WebAPI(token: token)
+//                self.webAPI = WebAPI(token: token)
+                self.addWebAPIAccessWithToken(token)
             }
             // Bot User
             if let token = authorization.bot?.botToken {
-                self.webAPI = WebAPI(token: token)
-                self.rtm = SKRTMAPI(withAPIToken: token, options: RTMOptions(), rtm: nil)
-                self.rtm?.adapter = self
-                self.clients[token] = Client()
-                self.rtm?.connect()
+                self.addRTMBotWithAPIToken(token)
+//                self.webAPI = WebAPI(token: token)
+//                self.rtm = SKRTMAPI(withAPIToken: token, options: RTMOptions(), rtm: nil)
+//                self.rtm?.adapter = self
+//                self.clients[token] = Client()
+//                self.rtm?.connect()
             }
         }
         return RequestRoute(path: "/oauth", middleware: oauth)
@@ -85,13 +115,13 @@ public final class SlackKit: RTMAdapter {
 
     // MARK: - RTM Adapter
     public func initialSetup(json: [String: Any], instance: SKRTMAPI) {
-        clients[instance.token]?.initialSetup(JSON: json)
+        clients[instance.token]?.client?.initialSetup(JSON: json)
     }
 
     public func notificationForEvent(_ event: Event, type: EventType, instance: SKRTMAPI) {
-        let client = clients[instance.token]
-        client?.notificationForEvent(event, type: type)
-        executeCallbackForEvent(event, type: type, client: client)
+        let clientConnection = clients[instance.token]
+        clientConnection?.client?.notificationForEvent(event, type: type)
+        executeCallbackForEvent(event, type: type, clientConnection: clientConnection)
     }
 
     // MARK: - Callbacks
@@ -99,10 +129,10 @@ public final class SlackKit: RTMAdapter {
         callbacks.append((type, event))
     }
 
-    private func executeCallbackForEvent(_ event: Event, type: EventType, client: Client?) {
+    private func executeCallbackForEvent(_ event: Event, type: EventType, clientConnection: ClientConnection?) {
         let cbs = callbacks.filter {$0.0 == type}
         for callback in cbs {
-            callback.1(event, client)
+            callback.1(event, clientConnection)
         }
     }
 }

--- a/Sources/SlackKit.swift
+++ b/Sources/SlackKit.swift
@@ -35,6 +35,15 @@ public final class SlackKit: RTMAdapter {
     internal var callbacks = [TypedEvent]()
     internal(set) public var server: SKServer?
     internal(set) public var clients: [String: ClientConnection] = [:]
+    
+    /// Return the `SKRTMAPI` instance of the first client
+    public var rtm: SKRTMAPI? {
+        return clients.values.first?.rtm
+    }
+    /// Return the `WebAPI` instance of the first client
+    public var webAPI: WebAPI? {
+        return clients.values.first?.webAPI
+    }
 
     public init() {}
 


### PR DESCRIPTION
Based on #118 this PR adds support for multiple Slack workspaces. SlackKit no longer has its own RTM and Web API instances, instead each client has its own. 