### PR TITLE
Add support for multiple files in a single event

### DIFF
--- a/SKClient/Sources/Client.swift
+++ b/SKClient/Sources/Client.swift
@@ -397,76 +397,82 @@ extension Client {
 // MARK: - Files
 extension Client {
     func processFile(_ event: Event) {
-        guard
-            let file = event.file,
-            let id = file.id
-        else {
-            return
-        }
-        if let comment = file.initialComment, let commentID = comment.id {
-            if files[id]?.comments[commentID] == nil {
-                files[id]?.comments[commentID] = comment
+        for file in event.files {
+            guard
+                let id = file.id
+            else {
+                continue
             }
+            if let comment = file.initialComment, let commentID = comment.id {
+                if files[id]?.comments[commentID] == nil {
+                    files[id]?.comments[commentID] = comment
+                }
+            }
+            files[id] = file
         }
-        files[id] = file
     }
 
     func filePrivate(_ event: Event) {
-        guard
-            let file =  event.file,
-            let id = file.id
-        else {
-            return
+        for file in event.files {
+            guard
+                let id = file.id
+            else {
+                continue
+            }
+            files[id]?.isPublic = false
         }
-        files[id]?.isPublic = false
     }
 
     func deleteFile(_ event: Event) {
-        guard
-            let file = event.file,
-            let id = file.id
-        else {
-            return
-        }
-        if files[id] != nil {
-            files.removeValue(forKey: id)
+        for file in event.files {
+            guard
+                let id = file.id
+            else {
+                continue
+            }
+            if files[id] != nil {
+                files.removeValue(forKey: id)
+            }
         }
     }
 
     func fileCommentAdded(_ event: Event) {
-        guard
-            let file = event.file,
-            let id = file.id,
-            let comment = event.comment,
-            let commentID = comment.id
-        else {
-            return
+        for file in event.files {
+            guard
+                let id = file.id,
+                let comment = event.comment,
+                let commentID = comment.id
+            else {
+                continue
+            }
+            files[id]?.comments[commentID] = comment
         }
-        files[id]?.comments[commentID] = comment
     }
 
     func fileCommentEdited(_ event: Event) {
-        guard
-            let file = event.file,
-            let id = file.id,
-            let comment = event.comment,
-            let commentID = comment.id
-        else {
-            return
+        for file in event.files {
+            guard
+                let id = file.id,
+                let comment = event.comment,
+                let commentID = comment.id
+            else {
+                continue
+            }
+            files[id]?.comments[commentID]?.comment = comment.comment
         }
-        files[id]?.comments[commentID]?.comment = comment.comment
     }
 
     func fileCommentDeleted(_ event: Event) {
-        guard
-            let file = event.file,
-            let id = file.id,
-            let comment = event.comment,
-            let commentID = comment.id
-        else {
-            return
+        for file in event.files {
+            guard
+                let id = file.id,
+                let comment = event.comment,
+                let commentID = comment.id
+            else {
+                continue
+            }
+            _ = files[id]?.comments.removeValue(forKey: commentID)
         }
-        _ = files[id]?.comments.removeValue(forKey: commentID)
     }
 }
 

--- a/SKCore/Sources/Event.swift
+++ b/SKCore/Sources/Event.swift
@@ -153,7 +153,7 @@ public class Event {
     public let channel: Channel?
     public let comment: Comment?
     public let user: User?
-    public let file: File?
+    public let files: [File]
     public let message: Message?
     public let nestedMessage: Message?
     public let itemUser: String?
@@ -197,7 +197,7 @@ public class Event {
         message = Message(dictionary: event)
         nestedMessage = Message(dictionary: event["message"] as? [String: Any])
         profile = CustomProfile(profile: event["profile"] as? [String: Any])
-        file = File(id: event["file"] as? String)
+        files = (event["files"] as? [Any])?.compactMap { File(file: $0 as? [String: Any]) } ?? []
 
         // Comment, Channel, and User can come across as Strings or Dictionaries
         if let commentDictionary = event["comment"] as? [String: Any] {


### PR DESCRIPTION
From the docs:

> The file attribute attached to messages is replaced with a new files field that includes an array of files in a different format instead.

https://api.slack.com/changelog/2018-05-file-threads-soon-tread