### PR TITLE
Add users.profile.set endpoint

### DIFF
--- a/SKCore/Sources/User.swift
+++ b/SKCore/Sources/User.swift
@@ -34,6 +34,9 @@ public struct User {
         public var image72: String?
         public var image192: String?
         public var customProfile: CustomProfile?
+        public var statusText: String?
+        public var statusEmoji: String?
+        public var statusExpiration: Int?
 
         public init(profile: [String: Any]?) {
             firstName = profile?["first_name"] as? String
@@ -47,6 +50,9 @@ public struct User {
             image72 = profile?["image_72"] as? String
             image192 = profile?["image_192"] as? String
             customProfile = CustomProfile(customFields: profile?["fields"] as? [String: Any])
+            statusText = profile?["status_text"] as? String
+            statusEmoji = profile?["status_emoji"] as? String
+            statusExpiration = profile?["status_expiration"] as? Int
         }
     }
 

--- a/SKWebAPI/Sources/Endpoint.swift
+++ b/SKWebAPI/Sources/Endpoint.swift
@@ -81,6 +81,7 @@ public enum Endpoint: String {
     case usersGetPresence = "users.getPresence"
     case usersInfo = "users.info"
     case usersList = "users.list"
+    case usersProfileSet = "users.profile.set"
     case usersSetActive = "users.setActive"
     case usersSetPresence = "users.setPresence"
 }

--- a/SKWebAPI/Sources/WebAPI.swift
+++ b/SKWebAPI/Sources/WebAPI.swift
@@ -1079,6 +1079,40 @@ extension WebAPI {
         }
     }
 
+    public func usersProfileSet(profile: User.Profile, success: SuccessClosure?, failure: FailureClosure?) {
+        let profileValues = ([
+            "first_name": profile.firstName,
+            "last_name": profile.lastName,
+            "real_name": profile.realName,
+            "email": profile.email,
+            "phone": profile.phone,
+            "status_text": profile.statusText,
+            "status_emoji": profile.statusEmoji,
+            "status_expiration": profile.statusExpiration,
+        ] as [String: Any?])
+        .filter { $0.value != nil }
+        .mapValues { $0! }
+
+        do {
+            let data = try JSONSerialization.data(withJSONObject: profileValues)
+            let json = String(data: data, encoding: .utf8)! as NSString
+            let encodedJSON = json.addingPercentEncoding(withAllowedCharacters: .urlQueryAllowed)!
+            var urlComponents = URLComponents(string: "https://slack.com/api/users.profile.set")!
+            urlComponents.queryItems = [URLQueryItem(name: "token", value: token),
+                                        URLQueryItem(name: "profile", value: encodedJSON)]
+
+            networkInterface.customRequest(urlComponents.url!.absoluteString, data: Data(), success: { _ in
+                success?(true)
+            }) {(error) in
+                failure?(error)
+            }
+        }
+        catch {
+            failure?(error as? SlackError ?? SlackError.unknownError)
+            return
+        }
+    } 
+
     public func setUserActive(success: SuccessClosure?, failure: FailureClosure?) {
         networkInterface.request(.usersSetActive, parameters: ["token": token], successClosure: { _ in
             success?(true)


### PR DESCRIPTION
This isn't an ideal implementation because it's not clear from the documentation if sending everything in the URL for a JSON request is supported, but this does work when tested manually. The intent of this PR is to add this functionality without requiring a larger change to how requests are created. This isn't complete support for the endpoint. In particular, custom profile fields won't be set.

https://api.slack.com/methods/users.profile.set

This has been verified with [this swift-sh script](https://github.com/interstateone/dotfiles/blob/master/work/bin/slack-calendar-status.swift#L7).