### PR TITLE
Add support for Ephemeral message API

### DIFF
--- a/SKWebAPI/Sources/Endpoint.swift
+++ b/SKWebAPI/Sources/Endpoint.swift
@@ -35,6 +35,7 @@ public enum Endpoint: String {
     case channelsSetTopic = "channels.setTopic"
     case chatDelete = "chat.delete"
     case chatPostMessage = "chat.postMessage"
+    case chatPostEphemeral = "chat.postEphemeral"
     case chatMeMessage = "chat.meMessage"
     case chatUpdate = "chat.update"
     case conversationsList = "conversations.list"

--- a/SKWebAPI/Sources/WebAPI.swift
+++ b/SKWebAPI/Sources/WebAPI.swift
@@ -312,6 +312,38 @@ extension WebAPI {
             failure?(error)
         }
     }
+    
+    public func sendEphemeral(
+        channel: String,
+        text: String,
+        user: String,
+        asUser: Bool? = nil,
+        parse: ParseMode? = nil,
+        linkNames: Bool? = nil,
+        attachments: [Attachment?]? = nil,
+        unfurlLinks: Bool? = nil,
+        unfurlMedia: Bool? = nil,
+        iconURL: String? = nil,
+        iconEmoji: String? = nil,
+        success: (((ts: String?, channel: String?)) -> Void)?,
+        failure: FailureClosure?
+        ) {
+        let parameters: [String: Any?] = [
+            "token": token,
+            "channel": channel,
+            "text": text,
+            "user": user,
+            "as_user": asUser,
+            "attachments": encodeAttachments(attachments),
+            "link_names": linkNames,
+            "parse": parse?.rawValue,
+            ]
+        networkInterface.request(.chatPostEphemeral, parameters: parameters, successClosure: {(response) in
+            success?((ts: response["sendMessage"] as? String, response["channel"] as? String))
+        }) {(error) in
+            failure?(error)
+        }
+    }
 
     public func sendMeMessage(
         channel: String,

--- a/SKWebAPI/Sources/WebAPI.swift
+++ b/SKWebAPI/Sources/WebAPI.swift
@@ -318,13 +318,9 @@ extension WebAPI {
         text: String,
         user: String,
         asUser: Bool? = nil,
-        parse: ParseMode? = nil,
-        linkNames: Bool? = nil,
         attachments: [Attachment?]? = nil,
-        unfurlLinks: Bool? = nil,
-        unfurlMedia: Bool? = nil,
-        iconURL: String? = nil,
-        iconEmoji: String? = nil,
+        linkNames: Bool? = nil,
+        parse: ParseMode? = nil,
         success: (((ts: String?, channel: String?)) -> Void)?,
         failure: FailureClosure?
         ) {


### PR DESCRIPTION
From this [Slack API Doc](https://api.slack.com/methods/chat.postEphemeral). I've added a new methods for WebAPI, it basically look same as sendMessage function, only difference is postEphemeral need to assign which user to send.


> Sends an ephemeral message to a user in a channel. Only visible to specific user in channel

[chat.postEphemeral](https://api.slack.com/methods/chat.postEphemeral)