### PR TITLE
Change the number of threads to 1 for VaporEngineRTM

### DIFF
--- a/SKRTMAPI/Sources/Conformers/VaporEngineRTM.swift
+++ b/SKRTMAPI/Sources/Conformers/VaporEngineRTM.swift
@@ -29,7 +29,7 @@ import WebSocket
 // Builds with *Swift Package Manager ONLY*
 public class VaporEngineRTM: RTMWebSocket {
 
-    private let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: System.coreCount)
+    private let eventLoopGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
     // Delegate
     public weak var delegate: RTMDelegate?
     // Websocket


### PR DESCRIPTION
After a LOT of reading through Vapor and SwiftNIO source and documentation, I've come to the conclusion that the websocket client doesn't actually use more than 1 thread. The best thing I've found to support this is the [Swift NIO documentation on `ClientBootstrap`](https://github.com/apple/swift-nio/blob/master/Sources/NIO/Bootstrap.swift#L349) which is ultimately what gets invoked via `HTTPClient.webSocket()`