### PR TITLE
Support sending ephemeral messages in threads

### DIFF
--- a/SKWebAPI/Sources/WebAPI.swift
+++ b/SKWebAPI/Sources/WebAPI.swift
@@ -314,23 +314,25 @@ extension WebAPI {
             failure?(error)
         }
     }
-    
+
     public func sendEphemeral(
         channel: String,
         text: String,
         user: String,
+        thread: String? = nil,
         asUser: Bool? = nil,
         attachments: [Attachment?]? = nil,
         linkNames: Bool? = nil,
         parse: ParseMode? = nil,
         success: (((ts: String?, channel: String?)) -> Void)?,
         failure: FailureClosure?
-        ) {
+    ) {
         let parameters: [String: Any?] = [
             "token": token,
             "channel": channel,
             "text": text,
             "user": user,
+            "thread_ts": thread,
             "as_user": asUser,
             "attachments": encodeAttachments(attachments),
             "link_names": linkNames,


### PR DESCRIPTION
Considered following the `Threaded` naming pattern like `sendThreadedMessage` but it seems unnecessary since you can't do the broadcast thing so there's no interplay between the 2 parameters being required/optional. This does the job, but I can obviously make it follow any pattern you prefer!