### PR TITLE
Fix typo SKRMTAPI -> SKRTMAPI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -58,7 +58,7 @@ let package = Package(
         .library(name: "SlackKit", targets: ["SlackKit"]),
         .library(name: "SKClient", targets: ["SKClient"]),
         .library(name: "SKCore", targets: ["SKCore"]),
-        .library(name: "SKRMTAPI", targets: ["SKRTMAPI"]),
+        .library(name: "SKRTMAPI", targets: ["SKRTMAPI"]),
         .library(name: "SKServer", targets: ["SKServer"]),
         .library(name: "SKWebAPI", targets: ["SKWebAPI"])
     ],


### PR DESCRIPTION
Hi there! This fixes a small issue I had when importing `SKRTMAPI` as a dependency on a Swift project. Any `build`, `run` or `generate-xcodeproj` failed with the following error:

```
error: product dependency 'SKRTMAPI' not found
```

After inspecting your `Package.swift`, I noticed a typo in `SKRTMAPI`: the product was declared as `SKRMTAPI`.