### PR TITLE
Codable vol.2 - CustomProfileField, DoNotDisturbStatus, TeamIcon and Topic

### DIFF
--- a/SKCore/Sources/Action.swift
+++ b/SKCore/Sources/Action.swift
@@ -45,15 +45,15 @@ public struct Action {
     public let dataSource: DataSource?
     
     public init(action: [String: Any]?) {
-        name = action?[CodingKeys.name.rawValue] as? String
-        text = action?[CodingKeys.text.rawValue] as? String
-        type = action?[CodingKeys.type.rawValue] as? String
-        value = action?[CodingKeys.value.rawValue] as? String
-        url = action?[CodingKeys.url.rawValue] as? String
-        style = ActionStyle(rawValue: action?[CodingKeys.style.rawValue] as? String ?? "")
-        confirm = Confirm(confirm:action?[CodingKeys.confirm.rawValue] as? [String: Any])
-        options = (action?[CodingKeys.options.rawValue] as? [[String: Any]])?.map { Option(option: $0) }
-        dataSource = DataSource(rawValue: action?[CodingKeys.dataSource.rawValue] as? String ?? "")
+        name = action?[CodingKeys.name] as? String
+        text = action?[CodingKeys.text] as? String
+        type = action?[CodingKeys.type] as? String
+        value = action?[CodingKeys.value] as? String
+        url = action?[CodingKeys.url] as? String
+        style = ActionStyle(rawValue: action?[CodingKeys.style] as? String ?? "")
+        confirm = Confirm(confirm:action?[CodingKeys.confirm] as? [String: Any])
+        options = (action?[CodingKeys.options] as? [[String: Any]])?.map { Option(option: $0) }
+        dataSource = DataSource(rawValue: action?[CodingKeys.dataSource] as? String ?? "")
     }
 
     public init(name: String, text: String, type: String = "button", style: ActionStyle = .defaultStyle, value: String? = nil,
@@ -71,15 +71,15 @@ public struct Action {
 
     public var dictionary: [String: Any] {
         var dict = [String: Any]()
-        dict[CodingKeys.name.rawValue] = name
-        dict[CodingKeys.text.rawValue] = text
-        dict[CodingKeys.type.rawValue] = type
-        dict[CodingKeys.value.rawValue] = value
-        dict[CodingKeys.url.rawValue] = url
-        dict[CodingKeys.style.rawValue] = style?.rawValue
-        dict[CodingKeys.confirm.rawValue] = confirm?.dictionary
-        dict[CodingKeys.options.rawValue] = options?.map { $0.dictionary }
-        dict[CodingKeys.dataSource.rawValue] = dataSource?.rawValue
+        dict[CodingKeys.name] = name
+        dict[CodingKeys.text] = text
+        dict[CodingKeys.type] = type
+        dict[CodingKeys.value] = value
+        dict[CodingKeys.url] = url
+        dict[CodingKeys.style] = style?.rawValue
+        dict[CodingKeys.confirm] = confirm?.dictionary
+        dict[CodingKeys.options] = options?.map { $0.dictionary }
+        dict[CodingKeys.dataSource] = dataSource?.rawValue
         return dict
     }
 
@@ -97,10 +97,10 @@ public struct Action {
         public let dismissText: String?
         
         public init(confirm: [String: Any]?) {
-            title = confirm?[CodingKeys.title.rawValue] as? String
-            text = confirm?[CodingKeys.text.rawValue] as? String
-            okText = confirm?[CodingKeys.okText.rawValue] as? String
-            dismissText = confirm?[CodingKeys.dismissText.rawValue] as? String
+            title = confirm?[CodingKeys.title] as? String
+            text = confirm?[CodingKeys.text] as? String
+            okText = confirm?[CodingKeys.okText] as? String
+            dismissText = confirm?[CodingKeys.dismissText] as? String
         }
 
         public init(text: String, title: String? = nil, okText: String? = nil, dismissText: String? = nil) {
@@ -112,10 +112,10 @@ public struct Action {
 
         public var dictionary: [String: Any] {
             var dict = [String: Any]()
-            dict[CodingKeys.title.rawValue] = title
-            dict[CodingKeys.text.rawValue] = text
-            dict[CodingKeys.okText.rawValue] = okText
-            dict[CodingKeys.dismissText.rawValue] = dismissText
+            dict[CodingKeys.title] = title
+            dict[CodingKeys.text] = text
+            dict[CodingKeys.okText] = okText
+            dict[CodingKeys.dismissText] = dismissText
             return dict
         }
     }
@@ -130,8 +130,8 @@ public struct Action {
         public let value: String?
         
         public init(option: [String: Any]?) {
-            text = option?[CodingKeys.text.rawValue] as? String
-            value = option?[CodingKeys.value.rawValue] as? String
+            text = option?[CodingKeys.text] as? String
+            value = option?[CodingKeys.value] as? String
         }
 
         public init(text: String, value: String) {
@@ -141,8 +141,8 @@ public struct Action {
 
         public var dictionary: [String: Any] {
             var dict = [String: Any]()
-            dict[CodingKeys.text.rawValue] = text
-            dict[CodingKeys.value.rawValue] = value
+            dict[CodingKeys.text] = text
+            dict[CodingKeys.value] = value
             return dict
         }
     }

--- a/SKCore/Sources/AttachmentField.swift
+++ b/SKCore/Sources/AttachmentField.swift
@@ -33,9 +33,9 @@ public struct AttachmentField {
     public let short: Bool?
     
     public init(field: [String: Any]?) {
-        title = field?[CodingKeys.title.rawValue] as? String
-        value = field?[CodingKeys.value.rawValue] as? String
-        short = field?[CodingKeys.short.rawValue] as? Bool
+        title = field?[CodingKeys.title] as? String
+        value = field?[CodingKeys.value] as? String
+        short = field?[CodingKeys.short] as? Bool
     }
 
     public init(title: String?, value: String?, short: Bool? = nil) {
@@ -46,9 +46,9 @@ public struct AttachmentField {
 
     public var dictionary: [String: Any] {
         var field = [String: Any]()
-        field[CodingKeys.title.rawValue] = title
-        field[CodingKeys.value.rawValue] = value
-        field[CodingKeys.short.rawValue] = short
+        field[CodingKeys.title] = title
+        field[CodingKeys.value] = value
+        field[CodingKeys.short] = short
         return field
     }
 }

--- a/SKCore/Sources/CustomProfileField.swift
+++ b/SKCore/Sources/CustomProfileField.swift
@@ -22,6 +22,19 @@
 // THE SOFTWARE.
 
 public struct CustomProfileField {
+    fileprivate enum CodingKeys: String {
+        case id
+        case alt
+        case value
+        case hidden = "is_hidden"
+        case hint
+        case label
+        case options
+        case ordering
+        case possibleValues = "possible_values"
+        case type
+    }
+    
     public var id: String?
     public var alt: String?
     public var value: String?
@@ -34,16 +47,16 @@ public struct CustomProfileField {
     public var type: String?
 
     public init(field: [String: Any]?) {
-        id = field?["id"] as? String
-        alt = field?["alt"] as? String
-        value = field?["value"] as? String
-        hidden = field?["is_hidden"] as? Bool
-        hint = field?["hint"] as? String
-        label = field?["label"] as? String
-        options = field?["options"] as? String
-        ordering = field?["ordering"] as? Int
-        possibleValues = field?["possible_values"] as? [String]
-        type = field?["type"] as? String
+        id = field?[CodingKeys.id] as? String
+        alt = field?[CodingKeys.alt] as? String
+        value = field?[CodingKeys.value] as? String
+        hidden = field?[CodingKeys.hidden] as? Bool
+        hint = field?[CodingKeys.hint] as? String
+        label = field?[CodingKeys.label] as? String
+        options = field?[CodingKeys.options] as? String
+        ordering = field?[CodingKeys.ordering] as? Int
+        possibleValues = field?[CodingKeys.possibleValues] as? [String]
+        type = field?[CodingKeys.type] as? String
     }
 
     public init(id: String?) {
@@ -63,3 +76,35 @@ public struct CustomProfileField {
         type = profile?.type != nil ? profile?.type : type
     }
 }
+
+extension CustomProfileField: Codable {
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        id = try values.decodeIfPresent(String.self, forKey: .id)
+        alt = try values.decodeIfPresent(String.self, forKey: .alt)
+        value = try values.decodeIfPresent(String.self, forKey: .value)
+        hidden = try values.decodeIfPresent(Bool.self, forKey: .hidden)
+        hint = try values.decodeIfPresent(String.self, forKey: .hint)
+        label = try values.decodeIfPresent(String.self, forKey: .label)
+        options = try values.decodeIfPresent(String.self, forKey: .options)
+        ordering = try values.decodeIfPresent(Int.self, forKey: .ordering)
+        possibleValues = try values.decodeIfPresent([String].self, forKey: .possibleValues)
+        type = try values.decodeIfPresent(String.self, forKey: .type)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(alt, forKey: .alt)
+        try container.encode(value, forKey: .value)
+        try container.encode(hidden, forKey: .hidden)
+        try container.encode(hint, forKey: .hint)
+        try container.encode(label, forKey: .label)
+        try container.encode(options, forKey: .options)
+        try container.encode(ordering, forKey: .ordering)
+        try container.encode(possibleValues, forKey: .possibleValues)
+        try container.encode(type, forKey: .type)
+    }
+}
+
+extension CustomProfileField.CodingKeys: CodingKey { }

--- a/SKCore/Sources/DoNotDisturbStatus.swift
+++ b/SKCore/Sources/DoNotDisturbStatus.swift
@@ -22,6 +22,14 @@
 // THE SOFTWARE.
 
 public struct DoNotDisturbStatus {
+    fileprivate enum CodingKeys: String {
+        case enabled = "dnd_enabled"
+        case nextDoNotDisturbStart = "next_dnd_start_ts"
+        case nextDoNotDisturbEnd = "next_dnd_end_ts"
+        case snoozeEnabled = "snooze_enabled"
+        case snoozeEndtime = "snooze_endtime"
+    }
+    
     public var enabled: Bool?
     public var nextDoNotDisturbStart: Int?
     public var nextDoNotDisturbEnd: Int?
@@ -29,10 +37,32 @@ public struct DoNotDisturbStatus {
     public var snoozeEndtime: Int?
 
     public init(status: [String: Any]?) {
-        enabled = status?["dnd_enabled"] as? Bool
-        nextDoNotDisturbStart = status?["next_dnd_start_ts"] as? Int
-        nextDoNotDisturbEnd = status?["next_dnd_end_ts"] as? Int
-        snoozeEnabled = status?["snooze_enabled"] as? Bool
-        snoozeEndtime = status?["snooze_endtime"] as? Int
+        enabled = status?[CodingKeys.enabled] as? Bool
+        nextDoNotDisturbStart = status?[CodingKeys.nextDoNotDisturbStart] as? Int
+        nextDoNotDisturbEnd = status?[CodingKeys.nextDoNotDisturbEnd] as? Int
+        snoozeEnabled = status?[CodingKeys.snoozeEnabled] as? Bool
+        snoozeEndtime = status?[CodingKeys.snoozeEndtime] as? Int
     }
 }
+
+extension DoNotDisturbStatus: Codable {
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        enabled = try values.decodeIfPresent(Bool.self, forKey: .enabled)
+        nextDoNotDisturbStart = try values.decodeIfPresent(Int.self, forKey: .nextDoNotDisturbStart)
+        nextDoNotDisturbEnd = try values.decodeIfPresent(Int.self, forKey: .nextDoNotDisturbEnd)
+        snoozeEnabled = try values.decodeIfPresent(Bool.self, forKey: .snoozeEnabled)
+        snoozeEndtime = try values.decodeIfPresent(Int.self, forKey: .snoozeEndtime)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(enabled, forKey: .enabled)
+        try container.encode(nextDoNotDisturbStart, forKey: .nextDoNotDisturbStart)
+        try container.encode(nextDoNotDisturbEnd, forKey: .nextDoNotDisturbEnd)
+        try container.encode(snoozeEnabled, forKey: .snoozeEnabled)
+        try container.encode(snoozeEndtime, forKey: .snoozeEndtime)
+    }
+}
+
+extension DoNotDisturbStatus.CodingKeys: CodingKey { }

--- a/SKCore/Sources/Edited.swift
+++ b/SKCore/Sources/Edited.swift
@@ -31,8 +31,8 @@ public struct Edited {
     public let ts: String?
 
     public init(edited: [String: Any]?) {
-        user = edited?[CodingKeys.user.rawValue] as? String
-        ts = edited?[CodingKeys.ts.rawValue] as? String
+        user = edited?[CodingKeys.user] as? String
+        ts = edited?[CodingKeys.ts] as? String
     }
 }
 

--- a/SKCore/Sources/Extensions.swift
+++ b/SKCore/Sources/Extensions.swift
@@ -39,6 +39,18 @@ public extension UInt64 {
     }
 }
 
+public extension Dictionary where Key == String, Value == Any {
+    subscript(codingKey: CodingKey) -> Any? {
+        get {
+            return self[codingKey.stringValue]
+        }
+    
+        set {
+            self[codingKey.stringValue] = newValue
+        }
+    }
+}
+
 public func filterNilParameters(_ parameters: [String: Any?]) -> [String: Any] {
     var finalParameters = [String: Any]()
     for (key, value) in parameters {

--- a/SKCore/Sources/Reply.swift
+++ b/SKCore/Sources/Reply.swift
@@ -31,8 +31,8 @@ public struct Reply {
     public let ts: String?
     
     public init(reply: [String: Any]?) {
-        user = reply?[CodingKeys.user.rawValue] as? String
-        ts = reply?[CodingKeys.ts.rawValue] as? String
+        user = reply?[CodingKeys.user] as? String
+        ts = reply?[CodingKeys.ts] as? String
     }
 }
 

--- a/SKCore/Sources/TeamIcon.swift
+++ b/SKCore/Sources/TeamIcon.swift
@@ -22,6 +22,17 @@
 // THE SOFTWARE.
 
 public struct TeamIcon {
+    fileprivate enum CodingKeys: String {
+        case image34 = "image_34"
+        case image44 = "image_44"
+        case image68 = "image_68"
+        case image88 = "image_88"
+        case image102 = "image_102"
+        case image132 = "image_132"
+        case imageOriginal = "image_original"
+        case imageDefault = "image_default"
+    }
+    
     public var image34: String?
     public var image44: String?
     public var image68: String?
@@ -32,13 +43,41 @@ public struct TeamIcon {
     public var imageDefault: Bool?
 
     public init(icon: [String: Any]?) {
-        image34 = icon?["image_34"] as? String
-        image44 = icon?["image_44"] as? String
-        image68 = icon?["image_68"] as? String
-        image88 = icon?["image_88"] as? String
-        image102 = icon?["image_102"] as? String
-        image132 = icon?["image_132"] as? String
-        imageOriginal = icon?["image_original"] as? String
-        imageDefault = icon?["image_default"] as? Bool
+        image34 = icon?[CodingKeys.image34] as? String
+        image44 = icon?[CodingKeys.image44] as? String
+        image68 = icon?[CodingKeys.image68] as? String
+        image88 = icon?[CodingKeys.image88] as? String
+        image102 = icon?[CodingKeys.image102] as? String
+        image132 = icon?[CodingKeys.image132] as? String
+        imageOriginal = icon?[CodingKeys.imageOriginal] as? String
+        imageDefault = icon?[CodingKeys.imageDefault] as? Bool
     }
 }
+
+extension TeamIcon: Codable {
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        image34 = try values.decodeIfPresent(String.self, forKey: .image34)
+        image44 = try values.decodeIfPresent(String.self, forKey: .image44)
+        image68 = try values.decodeIfPresent(String.self, forKey: .image68)
+        image88 = try values.decodeIfPresent(String.self, forKey: .image88)
+        image102 = try values.decodeIfPresent(String.self, forKey: .image102)
+        image132 = try values.decodeIfPresent(String.self, forKey: .image132)
+        imageOriginal = try values.decodeIfPresent(String.self, forKey: .imageOriginal)
+        imageDefault = try values.decodeIfPresent(Bool.self, forKey: .imageDefault)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(image34, forKey: .image34)
+        try container.encode(image44, forKey: .image44)
+        try container.encode(image68, forKey: .image68)
+        try container.encode(image88, forKey: .image88)
+        try container.encode(image102, forKey: .image102)
+        try container.encode(image132, forKey: .image132)
+        try container.encode(imageOriginal, forKey: .imageOriginal)
+        try container.encode(imageDefault, forKey: .imageDefault)
+    }
+}
+
+extension TeamIcon.CodingKeys: CodingKey { }

--- a/SKCore/Sources/Topic.swift
+++ b/SKCore/Sources/Topic.swift
@@ -22,13 +22,37 @@
 // THE SOFTWARE.
 
 public struct Topic {
+    fileprivate enum CodingKeys: String {
+        case value
+        case creator
+        case lastSet = "last_set"
+    }
+    
     public let value: String?
     public let creator: String?
     public let lastSet: Int?
 
     public init(topic: [String: Any]?) {
-        value = topic?["value"] as? String
-        creator = topic?["creator"] as? String
-        lastSet = topic?["last_set"] as? Int
+        value = topic?[CodingKeys.value] as? String
+        creator = topic?[CodingKeys.creator] as? String
+        lastSet = topic?[CodingKeys.lastSet] as? Int
     }
 }
+
+extension Topic: Codable {
+    public init(from decoder: Decoder) throws {
+        let values = try decoder.container(keyedBy: CodingKeys.self)
+        value = try values.decodeIfPresent(String.self, forKey: .value)
+        creator = try values.decodeIfPresent(String.self, forKey: .creator)
+        lastSet = try values.decodeIfPresent(Int.self, forKey: .lastSet)
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(value, forKey: .value)
+        try container.encode(creator, forKey: .creator)
+        try container.encode(lastSet, forKey: .lastSet)
+    }
+}
+
+extension Topic.CodingKeys: CodingKey { }

--- a/SlackKit.xcodeproj/project.pbxproj
+++ b/SlackKit.xcodeproj/project.pbxproj
@@ -119,13 +119,17 @@
 		26D4E6082212120900A67B67 /* SKRTMAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 26D4E5FE221211B900A67B67 /* SKRTMAPI.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		26D4E6092212120F00A67B67 /* SKServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 26D4E600221211B900A67B67 /* SKServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		26D4E60A2212121400A67B67 /* SKWebAPI.h in Headers */ = {isa = PBXBuildFile; fileRef = 26D4E601221211B900A67B67 /* SKWebAPI.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		A20D15EA22DE158000044CFC /* BlockComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20D15E722DE158000044CFC /* BlockComposition.swift */; };
-		A20D15EB22DE158000044CFC /* BlockElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20D15E822DE158000044CFC /* BlockElement.swift */; };
-		A20D15EC22DE158000044CFC /* BlockLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20D15E922DE158000044CFC /* BlockLayout.swift */; };
+		9E452ACF22F2376B005E731B /* donotdisturbstatus.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E452ACE22F2376B005E731B /* donotdisturbstatus.json */; };
+		9E452AD122F237FD005E731B /* customprofilefield.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E452AD022F237FD005E731B /* customprofilefield.json */; };
+		9E873EFE22EA4A36005ABC26 /* topic.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E873EFD22EA4A36005ABC26 /* topic.json */; };
+		9E873F0222EA5413005ABC26 /* teamicon.json in Resources */ = {isa = PBXBuildFile; fileRef = 9E873F0122EA5413005ABC26 /* teamicon.json */; };
 		9EA45FB922C01290006A6D36 /* action.json in Resources */ = {isa = PBXBuildFile; fileRef = 9EA45FB822C01290006A6D36 /* action.json */; };
 		9EE6A7C322C2CDD6002BD111 /* edited.json in Resources */ = {isa = PBXBuildFile; fileRef = 9EE6A7C222C2CDD6002BD111 /* edited.json */; };
 		9EEC459622BE63F800206AC3 /* reply.json in Resources */ = {isa = PBXBuildFile; fileRef = 9EEC459522BE63F800206AC3 /* reply.json */; };
 		9EEC459822BE789600206AC3 /* attachmentfield.json in Resources */ = {isa = PBXBuildFile; fileRef = 9EEC459722BE789600206AC3 /* attachmentfield.json */; };
+		A20D15EA22DE158000044CFC /* BlockComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20D15E722DE158000044CFC /* BlockComposition.swift */; };
+		A20D15EB22DE158000044CFC /* BlockElement.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20D15E822DE158000044CFC /* BlockElement.swift */; };
+		A20D15EC22DE158000044CFC /* BlockLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = A20D15E922DE158000044CFC /* BlockLayout.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -318,13 +322,17 @@
 		26D4E6292220731800A67B67 /* rtm.connect.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = rtm.connect.json; sourceTree = "<group>"; };
 		26D4E62A2220731800A67B67 /* file.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = file.json; sourceTree = "<group>"; };
 		26D4E6362220733F00A67B67 /* SKCoreTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SKCoreTests.swift; sourceTree = "<group>"; };
-		A20D15E722DE158000044CFC /* BlockComposition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockComposition.swift; sourceTree = "<group>"; };
-		A20D15E822DE158000044CFC /* BlockElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockElement.swift; sourceTree = "<group>"; };
-		A20D15E922DE158000044CFC /* BlockLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockLayout.swift; sourceTree = "<group>"; };
+		9E452ACE22F2376B005E731B /* donotdisturbstatus.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = donotdisturbstatus.json; sourceTree = "<group>"; };
+		9E452AD022F237FD005E731B /* customprofilefield.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = customprofilefield.json; sourceTree = "<group>"; };
+		9E873EFD22EA4A36005ABC26 /* topic.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = topic.json; sourceTree = "<group>"; };
+		9E873F0122EA5413005ABC26 /* teamicon.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = teamicon.json; sourceTree = "<group>"; };
 		9EA45FB822C01290006A6D36 /* action.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = action.json; sourceTree = "<group>"; };
 		9EE6A7C222C2CDD6002BD111 /* edited.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = edited.json; sourceTree = "<group>"; };
 		9EEC459522BE63F800206AC3 /* reply.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = reply.json; sourceTree = "<group>"; };
 		9EEC459722BE789600206AC3 /* attachmentfield.json */ = {isa = PBXFileReference; lastKnownFileType = text.json; path = attachmentfield.json; sourceTree = "<group>"; };
+		A20D15E722DE158000044CFC /* BlockComposition.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockComposition.swift; sourceTree = "<group>"; };
+		A20D15E822DE158000044CFC /* BlockElement.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockElement.swift; sourceTree = "<group>"; };
+		A20D15E922DE158000044CFC /* BlockLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = BlockLayout.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -839,6 +847,8 @@
 				9EEC459722BE789600206AC3 /* attachmentfield.json */,
 				26D4E6282220731800A67B67 /* channel.json */,
 				26D4E6222220731700A67B67 /* conversation.json */,
+				9E452AD022F237FD005E731B /* customprofilefield.json */,
+				9E452ACE22F2376B005E731B /* donotdisturbstatus.json */,
 				9EE6A7C222C2CDD6002BD111 /* edited.json */,
 				26D4E6262220731800A67B67 /* events.json */,
 				26D4E62A2220731800A67B67 /* file.json */,
@@ -848,6 +858,8 @@
 				9EEC459522BE63F800206AC3 /* reply.json */,
 				26D4E6292220731800A67B67 /* rtm.connect.json */,
 				26D4E6202220731700A67B67 /* rtm.start.json */,
+				9E873F0122EA5413005ABC26 /* teamicon.json */,
+				9E873EFD22EA4A36005ABC26 /* topic.json */,
 				26D4E6242220731800A67B67 /* user.json */,
 				26D4E6252220731800A67B67 /* usergroup.json */,
 				2601B70D222F766D00F197AB /* member_joined_channel.json */,
@@ -1209,11 +1221,15 @@
 				9EA45FB922C01290006A6D36 /* action.json in Resources */,
 				2601B710222F766D00F197AB /* member_left_channel.json in Resources */,
 				2601B6CE2223038A00F197AB /* conversation.json in Resources */,
+				9E873F0222EA5413005ABC26 /* teamicon.json in Resources */,
 				2601B70F222F766D00F197AB /* member_joined_channel.json in Resources */,
 				2601B6CF2223038A00F197AB /* events.json in Resources */,
+				9E452AD122F237FD005E731B /* customprofilefield.json in Resources */,
 				2601B6D02223038A00F197AB /* file.json in Resources */,
+				9E452ACF22F2376B005E731B /* donotdisturbstatus.json in Resources */,
 				2601B6D12223038A00F197AB /* group.json in Resources */,
 				2601B6D22223038A00F197AB /* im.json in Resources */,
+				9E873EFE22EA4A36005ABC26 /* topic.json in Resources */,
 				2601B6D32223038A00F197AB /* mpim.json in Resources */,
 				2601B6D42223038A00F197AB /* rtm.connect.json in Resources */,
 				2601B6D52223038A00F197AB /* rtm.start.json in Resources */,

--- a/SlackKitTests/Resources/customprofilefield.json
+++ b/SlackKitTests/Resources/customprofilefield.json
@@ -1,0 +1,12 @@
+{
+    "id": "any id",
+    "alt": "any alt",
+    "value": "any value",
+    "is_hidden": true,
+    "hint": "any hint",
+    "label": "any label",
+    "options": "any options",
+    "ordering": 1,
+    "possible_values": ["first value", "second value"],
+    "type": "any type"
+}

--- a/SlackKitTests/Resources/donotdisturbstatus.json
+++ b/SlackKitTests/Resources/donotdisturbstatus.json
@@ -1,0 +1,7 @@
+{
+    "dnd_enabled": false,
+    "next_dnd_start_ts": 1000,
+    "next_dnd_end_ts": 2000,
+    "snooze_enabled": true,
+    "snooze_endtime": 3000
+}

--- a/SlackKitTests/Resources/teamicon.json
+++ b/SlackKitTests/Resources/teamicon.json
@@ -1,0 +1,10 @@
+{
+    "image_34": "image 34",
+    "image_44": "image 44",
+    "image_68": "image 68",
+    "image_88": "image 88",
+    "image_102": "image 102",
+    "image_132": "image 132",
+    "image_original": "image original",
+    "image_default": true
+}

--- a/SlackKitTests/Resources/topic.json
+++ b/SlackKitTests/Resources/topic.json
@@ -1,0 +1,5 @@
+{
+    "value": "any value",
+    "creator": "any creator",
+    "last_set": 1000
+}

--- a/SlackKitTests/SKCore/SKCoreTests.swift
+++ b/SlackKitTests/SKCore/SKCoreTests.swift
@@ -46,8 +46,12 @@ final class SKCoreTests: XCTestCase {
         static let events           = try! Data(contentsOf: URL(fileURLWithPath: "\(rootPath)/events.json"))
         static let action           = try! Data(contentsOf: URL(fileURLWithPath: "\(rootPath)/action.json"))
         static let attachmentfield  = try! Data(contentsOf: URL(fileURLWithPath: "\(rootPath)/attachmentfield.json"))
+        static let customprofilefield = try! Data(contentsOf: URL(fileURLWithPath: "\(rootPath)/customprofilefield.json"))
+        static let donotdisturbstatus = try! Data(contentsOf: URL(fileURLWithPath: "\(rootPath)/donotdisturbstatus.json"))
         static let edited           = try! Data(contentsOf: URL(fileURLWithPath: "\(rootPath)/edited.json"))
         static let reply            = try! Data(contentsOf: URL(fileURLWithPath: "\(rootPath)/reply.json"))
+        static let teamicon         = try! Data(contentsOf: URL(fileURLWithPath: "\(rootPath)/teamicon.json"))
+        static let topic            = try! Data(contentsOf: URL(fileURLWithPath: "\(rootPath)/topic.json"))
     }
 
     static var allTests = [
@@ -62,7 +66,8 @@ final class SKCoreTests: XCTestCase {
         ("testEvents", testEvents),
         ("testActionCodable", testActionCodable),
         ("testAttachmentFieldCodable", testAttachmentFieldCodable),
-        ("testReplyCodable", testReplyCodable)
+        ("testReplyCodable", testReplyCodable),
+        ("testTopicCodable", testTopicCodable)
     ]
   
   func testEvents() {
@@ -203,6 +208,39 @@ final class SKCoreTests: XCTestCase {
     XCTAssertEqual(attachmentFieldBySerialization.short, attachmentFieldByDecoder!.short)
   }
     
+  func testCustomProfileFieldCodable() {
+    let data = JSONData.customprofilefield
+    let decoder = JSONDecoder()
+    let customProfileFieldByDecoder = try? decoder.decode(CustomProfileField.self, from: data)
+    XCTAssertNotNil(customProfileFieldByDecoder)
+    XCTAssertNotNil(customProfileFieldByDecoder!.id)
+    XCTAssertNotNil(customProfileFieldByDecoder!.alt)
+    XCTAssertNotNil(customProfileFieldByDecoder!.value)
+    XCTAssertNotNil(customProfileFieldByDecoder!.hidden)
+    XCTAssertNotNil(customProfileFieldByDecoder!.hint)
+    XCTAssertNotNil(customProfileFieldByDecoder!.label)
+    XCTAssertNotNil(customProfileFieldByDecoder!.options)
+    XCTAssertNotNil(customProfileFieldByDecoder!.ordering)
+    XCTAssertNotNil(customProfileFieldByDecoder!.possibleValues)
+    XCTAssertNotNil(customProfileFieldByDecoder!.type)
+    let encoder = JSONEncoder()
+    let jsonData = try? encoder.encode(customProfileFieldByDecoder!)
+    XCTAssertNotNil(jsonData)
+    let field = try? JSONSerialization.jsonObject(with: jsonData!, options: []) as? [String: Any]
+    XCTAssertNotNil(field)
+    let customProfileFieldBySerialization = CustomProfileField(field: field)
+    XCTAssertEqual(customProfileFieldBySerialization.id, customProfileFieldByDecoder!.id)
+    XCTAssertEqual(customProfileFieldBySerialization.alt, customProfileFieldByDecoder!.alt)
+    XCTAssertEqual(customProfileFieldBySerialization.value, customProfileFieldByDecoder!.value)
+    XCTAssertEqual(customProfileFieldBySerialization.hidden, customProfileFieldByDecoder!.hidden)
+    XCTAssertEqual(customProfileFieldBySerialization.hint, customProfileFieldByDecoder!.hint)
+    XCTAssertEqual(customProfileFieldBySerialization.label, customProfileFieldByDecoder!.label)
+    XCTAssertEqual(customProfileFieldBySerialization.options, customProfileFieldByDecoder!.options)
+    XCTAssertEqual(customProfileFieldBySerialization.ordering, customProfileFieldByDecoder!.ordering)
+    XCTAssertEqual(customProfileFieldBySerialization.possibleValues, customProfileFieldByDecoder!.possibleValues)
+    XCTAssertEqual(customProfileFieldBySerialization.type, customProfileFieldByDecoder!.type)
+  }
+    
   func testEditedCodable() {
     let data = JSONData.edited
     let decoder = JSONDecoder()
@@ -235,5 +273,24 @@ final class SKCoreTests: XCTestCase {
     let replyBySerialization = Reply(reply: reply)
     XCTAssertEqual(replyBySerialization.user, replyByDecoder!.user)
     XCTAssertEqual(replyBySerialization.ts, replyByDecoder!.ts)
+  }
+    
+  func testTopicCodable() {
+    let data = JSONData.topic
+    let decoder = JSONDecoder()
+    let topicByDecoder = try? decoder.decode(Topic.self, from: data)
+    XCTAssertNotNil(topicByDecoder)
+    XCTAssertNotNil(topicByDecoder!.value)
+    XCTAssertNotNil(topicByDecoder!.creator)
+    XCTAssertNotNil(topicByDecoder!.lastSet)
+    let encoder = JSONEncoder()
+    let jsonData = try? encoder.encode(topicByDecoder!)
+    XCTAssertNotNil(jsonData)
+    let topic = try? JSONSerialization.jsonObject(with: jsonData!, options: []) as? [String: Any]
+    XCTAssertNotNil(topic)
+    let topicBySerialization = Topic(topic: topic)
+    XCTAssertEqual(topicBySerialization.value, topicByDecoder!.value)
+    XCTAssertEqual(topicBySerialization.creator, topicByDecoder!.creator)
+    XCTAssertEqual(topicBySerialization.lastSet, topicByDecoder!.lastSet)
   }
 }

--- a/SlackKitTests/SKCore/SKCoreTests.swift
+++ b/SlackKitTests/SKCore/SKCoreTests.swift
@@ -66,7 +66,11 @@ final class SKCoreTests: XCTestCase {
         ("testEvents", testEvents),
         ("testActionCodable", testActionCodable),
         ("testAttachmentFieldCodable", testAttachmentFieldCodable),
+        ("testCustomProfileFieldCodable", testCustomProfileFieldCodable),
+        ("testDoNotDisturbStatusCodable", testDoNotDisturbStatusCodable),
+        ("testEditedCodable", testEditedCodable),
         ("testReplyCodable", testReplyCodable),
+        ("testTeamIconCodable", testTeamIconCodable),
         ("testTopicCodable", testTopicCodable)
     ]
   
@@ -241,6 +245,29 @@ final class SKCoreTests: XCTestCase {
     XCTAssertEqual(customProfileFieldBySerialization.type, customProfileFieldByDecoder!.type)
   }
     
+  func testDoNotDisturbStatusCodable() {
+    let data = JSONData.donotdisturbstatus
+    let decoder = JSONDecoder()
+    let doNotDisturbStatusByDecoder = try? decoder.decode(DoNotDisturbStatus.self, from: data)
+    XCTAssertNotNil(doNotDisturbStatusByDecoder)
+    XCTAssertNotNil(doNotDisturbStatusByDecoder!.enabled)
+    XCTAssertNotNil(doNotDisturbStatusByDecoder!.nextDoNotDisturbStart)
+    XCTAssertNotNil(doNotDisturbStatusByDecoder!.nextDoNotDisturbEnd)
+    XCTAssertNotNil(doNotDisturbStatusByDecoder!.snoozeEnabled)
+    XCTAssertNotNil(doNotDisturbStatusByDecoder!.snoozeEndtime)
+    let encoder = JSONEncoder()
+    let jsonData = try? encoder.encode(doNotDisturbStatusByDecoder!)
+    XCTAssertNotNil(jsonData)
+    let status = try? JSONSerialization.jsonObject(with: jsonData!, options: []) as? [String: Any]
+    XCTAssertNotNil(status)
+    let doNotDisturbStatusBySerialization = DoNotDisturbStatus(status: status)
+    XCTAssertEqual(doNotDisturbStatusBySerialization.enabled, doNotDisturbStatusByDecoder!.enabled)
+    XCTAssertEqual(doNotDisturbStatusBySerialization.nextDoNotDisturbStart, doNotDisturbStatusByDecoder!.nextDoNotDisturbStart)
+    XCTAssertEqual(doNotDisturbStatusBySerialization.nextDoNotDisturbEnd, doNotDisturbStatusByDecoder!.nextDoNotDisturbEnd)
+    XCTAssertEqual(doNotDisturbStatusBySerialization.snoozeEnabled, doNotDisturbStatusByDecoder!.snoozeEnabled)
+    XCTAssertEqual(doNotDisturbStatusBySerialization.snoozeEndtime, doNotDisturbStatusByDecoder!.snoozeEndtime)
+  }
+    
   func testEditedCodable() {
     let data = JSONData.edited
     let decoder = JSONDecoder()
@@ -273,6 +300,35 @@ final class SKCoreTests: XCTestCase {
     let replyBySerialization = Reply(reply: reply)
     XCTAssertEqual(replyBySerialization.user, replyByDecoder!.user)
     XCTAssertEqual(replyBySerialization.ts, replyByDecoder!.ts)
+  }
+    
+  func testTeamIconCodable() {
+    let data = JSONData.teamicon
+    let decoder = JSONDecoder()
+    let teamIconByDecoder = try? decoder.decode(TeamIcon.self, from: data)
+    XCTAssertNotNil(teamIconByDecoder)
+    XCTAssertNotNil(teamIconByDecoder!.image34)
+    XCTAssertNotNil(teamIconByDecoder!.image44)
+    XCTAssertNotNil(teamIconByDecoder!.image68)
+    XCTAssertNotNil(teamIconByDecoder!.image88)
+    XCTAssertNotNil(teamIconByDecoder!.image102)
+    XCTAssertNotNil(teamIconByDecoder!.image132)
+    XCTAssertNotNil(teamIconByDecoder!.imageOriginal)
+    XCTAssertNotNil(teamIconByDecoder!.imageDefault)
+    let encoder = JSONEncoder()
+    let jsonData = try? encoder.encode(teamIconByDecoder!)
+    XCTAssertNotNil(jsonData)
+    let icon = try? JSONSerialization.jsonObject(with: jsonData!, options: []) as? [String: Any]
+    XCTAssertNotNil(icon)
+    let teamIconBySerialization = TeamIcon(icon: icon)
+    XCTAssertEqual(teamIconBySerialization.image34, teamIconByDecoder!.image34)
+    XCTAssertEqual(teamIconBySerialization.image44, teamIconByDecoder!.image44)
+    XCTAssertEqual(teamIconBySerialization.image68, teamIconByDecoder!.image68)
+    XCTAssertEqual(teamIconBySerialization.image88, teamIconByDecoder!.image88)
+    XCTAssertEqual(teamIconBySerialization.image102, teamIconByDecoder!.image102)
+    XCTAssertEqual(teamIconBySerialization.image132, teamIconByDecoder!.image132)
+    XCTAssertEqual(teamIconBySerialization.imageOriginal, teamIconByDecoder!.imageOriginal)
+    XCTAssertEqual(teamIconBySerialization.imageDefault, teamIconByDecoder!.imageDefault)
   }
     
   func testTopicCodable() {

--- a/SlackKitTests/XCTestManifests.swift
+++ b/SlackKitTests/XCTestManifests.swift
@@ -20,8 +20,11 @@ extension SKCoreTests {
         ("testUserGroup", testUserGroup),
         ("testActionCodable", testActionCodable),
         ("testAttachmentFieldCodable", testAttachmentFieldCodable),
+        ("testCustomProfileFieldCodable", testCustomProfileFieldCodable),
+        ("testDoNotDisturbStatusCodable", testDoNotDisturbStatusCodable),
         ("testEditedCodable", testEditedCodable),
         ("testReplyCodable", testReplyCodable),
+        ("testTeamIconCodable", testTeamIconCodable),
         ("testTopicCodable", testTopicCodable),
     ]
 }

--- a/SlackKitTests/XCTestManifests.swift
+++ b/SlackKitTests/XCTestManifests.swift
@@ -22,6 +22,7 @@ extension SKCoreTests {
         ("testAttachmentFieldCodable", testAttachmentFieldCodable),
         ("testEditedCodable", testEditedCodable),
         ("testReplyCodable", testReplyCodable),
+        ("testTopicCodable", testTopicCodable),
     ]
 }
 


### PR DESCRIPTION
Hello.
In this pull request I added `Codable` conformance for `CustomProfileField`, `DoNotDisturbStatus`, `TeamIcon` and `Topic`, started it in #163 (described in #122).
Also added a special extension for `[String:Any]`, it helps to reduce the number of `.rawValue` calls.