### PR TITLE
Support users.conversations in WebAPI

### DIFF
--- a/SKWebAPI/Sources/Endpoint.swift
+++ b/SKWebAPI/Sources/Endpoint.swift
@@ -89,6 +89,7 @@ public enum Endpoint: String {
     case usersGetPresence = "users.getPresence"
     case usersInfo = "users.info"
     case usersList = "users.list"
+    case usersConversations = "users.conversations"
     case usersLookupByEmail = "users.lookupByEmail"
     case usersProfileSet = "users.profile.set"
     case usersSetActive = "users.setActive"


### PR DESCRIPTION
https://api.slack.com/methods/users.conversations

Response type is similar to `conversationsList` in SKWebAPI.swift.
But I want to receive the result as `Array<Channel>`, I create a `ChannelsClosure`.

If you want to, I can refactor `conversationsList` to use `ChannelsClosure`
(it breaks back compatible)