### PR TITLE
Use Dictionary.compactMapValues

### DIFF
--- a/SKCore/Sources/Extensions.swift
+++ b/SKCore/Sources/Extensions.swift
@@ -50,13 +50,3 @@ public extension Dictionary where Key == String, Value == Any {
         }
     }
 }
-
-public func filterNilParameters(_ parameters: [String: Any?]) -> [String: Any] {
-    var finalParameters = [String: Any]()
-    for (key, value) in parameters {
-        if let unwrapped = value {
-            finalParameters[key] = unwrapped
-        }
-    }
-    return finalParameters
-}

--- a/SKRTMAPI/Sources/SKRTMAPI.swift
+++ b/SKRTMAPI/Sources/SKRTMAPI.swift
@@ -160,7 +160,7 @@ public final class SKRTMAPI: RTMDelegate {
             "broadcastReply": broadcastReply
         ]
         guard
-            let data = try? JSONSerialization.data(withJSONObject: filterNilParameters(json), options: []),
+            let data = try? JSONSerialization.data(withJSONObject: json.compactMapValues({$0}), options: []),
             let str = String(data: data, encoding: String.Encoding.utf8)
         else {
             throw SlackError.clientJSONError

--- a/SKWebAPI/Sources/NetworkInterface.swift
+++ b/SKWebAPI/Sources/NetworkInterface.swift
@@ -178,7 +178,7 @@ public struct NetworkInterface {
     private func requestURL(for endpoint: Endpoint, parameters: [String: Any?]) -> URL? {
         var components = URLComponents(string: "\(apiUrl)\(endpoint.rawValue)")
         if parameters.count > 0 {
-            components?.queryItems = filterNilParameters(parameters).map { URLQueryItem(name: $0.0, value: "\($0.1)") }
+            components?.queryItems = parameters.compactMapValues({$0}).map { URLQueryItem(name: $0.0, value: "\($0.1)") }
         }
 
         // As discussed http://www.openradar.me/24076063 and https://stackoverflow.com/a/37314144/407523, Apple considers

--- a/SKWebAPI/Sources/WebAPI.swift
+++ b/SKWebAPI/Sources/WebAPI.swift
@@ -1130,7 +1130,7 @@ extension WebAPI {
             "types": types?.map({ $0.rawValue }).joined(separator: ","),
             "user": userID
         ]
-        networkInterface.request(.usersConversations, parameters: parameters.compactMapValues({$0}), successClosure: {(response) in
+        networkInterface.request(.usersConversations, parameters: parameters, successClosure: {(response) in
             let channels: [Channel] = (response["channels"] as? [[String: Any]])?.map{Channel(channel: $0)} ?? []
             success?(channels, (response["response_metadata"] as? [String: Any])?["next_cursor"] as? String)
         }) {(error) in


### PR DESCRIPTION
In #179, I use Dictionary.compactMapValues in WebAPI `users.conversations`.
I notice SKCore presents `filterNilParameters` which is same as `Dictionary.compactMapValues({$0})` .

SlackKit is written in Swift 5.x now, we can use `compactMapValues` all over the project.