### PR TITLE
Fix event type name of email_domain_changed

### DIFF
--- a/SKClient/Sources/Client.swift
+++ b/SKClient/Sources/Client.swift
@@ -146,8 +146,8 @@ open class Client {
             teamNameChange(event)
         case .teamDomainChange:
             teamDomainChange(event)
-        case .emailDomainChange:
-            emailDomainChange(event)
+        case .emailDomainChanged:
+            emailDomainChanged(event)
         case .teamProfileChange:
             teamProfileChange(event)
         case .teamProfileDelete:
@@ -757,7 +757,7 @@ extension Client {
         team?.domain = domain
     }
 
-    func emailDomainChange(_ event: Event) {
+    func emailDomainChanged(_ event: Event) {
         guard let domain = event.emailDomain else {
             return
         }

--- a/SKCore/Sources/Event.swift
+++ b/SKCore/Sources/Event.swift
@@ -80,7 +80,7 @@ public enum EventType: String {
     case teamPrefChange = "team_pref_change"
     case teamRename = "team_rename"
     case teamDomainChange = "team_domain_change"
-    case emailDomainChange = "email_domain_change"
+    case emailDomainChanged = "email_domain_changed"
     case teamProfileChange = "team_profile_change"
     case teamProfileDelete = "team_profile_delete"
     case teamProfileReorder = "team_profile_reorder"


### PR DESCRIPTION
I found typo of [email_domain_changed](https://api.slack.com/events/email_domain_changed), using event types of https://api.slack.com/rtm

P.S. `file_private` is defined in Event.swift, but not listed in [event type list](https://api.slack.com/rtm).
Still https://github.com/slackhq/slack-api-docs/blob/master/events/file_private.md exists, but
https://api.slack.com/events/file_private is not found.
It seems to be deleted, IMO.
