### PR TITLE
Adding connectionClosed in client

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ let SlackKit: Target = .target(name: "SlackKit",
                                path: "SlackKit/Sources")
 
 let SKClient: Target = .target(name: "SKClient",
-                               dependencies: ["SKCore"],
+                               dependencies: ["SKCore", "SKRTMAPI"],
                                path: "SKClient/Sources")
 
 let SKCore: Target   = .target(name: "SKCore",

--- a/SKClient/Sources/Client.swift
+++ b/SKClient/Sources/Client.swift
@@ -27,6 +27,7 @@ import Dispatch
 import Foundation
 #if !COCOAPODS
 @_exported import SKCore
+@_exported import SKRTMAPI
 #endif
 
 open class Client {
@@ -202,6 +203,8 @@ open class Client {
         enumerateObjects(JSON["bots"] as? Array) { (bots) in self.addBot(bots) }
         enumerateSubteams(JSON["subteams"] as? [String: Any])
     }
+
+    open func connectionClosed(error: Error, instance: SKRTMAPI) {	}
 
     private func messageDispatcher(_ event: Event) {
         guard let value = event.subtype, let subtype = MessageSubtype(rawValue:value) else {

--- a/SlackKit.podspec
+++ b/SlackKit.podspec
@@ -24,6 +24,7 @@ Pod::Spec.new do |s|
   s.subspec "SKClient" do |ss|
     ss.source_files = "SKClient/Sources/"
     ss.dependency "SlackKit/SKCore"
+    ss.dependency "SlackKit/SKRTMAPI"
   end
 
   s.subspec "SKCore" do |ss|

--- a/SlackKit/Sources/SlackKit.swift
+++ b/SlackKit/Sources/SlackKit.swift
@@ -109,7 +109,12 @@ public final class SlackKit: RTMAdapter {
         executeCallbackForEvent(event, type: type, clientConnection: clientConnection)
     }
 
-    public func connectionClosed(with error: Error, instance: SKRTMAPI) {}
+    public func connectionClosed(with error: Error, instance: SKRTMAPI) {
+        clients[instance.token]?.client?.connectionClosed(error: error, instance: instance)
+        clients[instance.token]?.client = nil
+        clients[instance.token]?.rtm = nil
+        clients[instance.token] = nil
+    }
 
     // MARK: - Callbacks
     public func notificationForEvent(_ type: EventType, event: @escaping EventClosure) {


### PR DESCRIPTION
This change enables the implementation of `connectionClosed` in the client which is useful to catch situations such as invalid tokens, etc. and then clean up.

I decided to free up the client instance as I typically see this condition with an invalid token, but as some things are indexed by token attempting a reconnect would normally be unsuccessful.