### PR TITLE
Allow files to be uploaded to threads

### DIFF
--- a/SKWebAPI/Sources/WebAPI.swift
+++ b/SKWebAPI/Sources/WebAPI.swift
@@ -495,6 +495,7 @@ extension WebAPI {
         title: String? = nil,
         initialComment: String? = nil,
         channels: [String]? = nil,
+        ts: String? = nil,
         success: FileClosure?,
         failure: FailureClosure?
     ) {
@@ -504,7 +505,8 @@ extension WebAPI {
             "filetype": filetype,
             "title": title,
             "initial_comment": initialComment,
-            "channels": channels?.joined(separator: ",")
+            "channels": channels?.joined(separator: ","),
+            "thread_ts": ts
         ]
         networkInterface.uploadRequest(data: file, parameters: parameters, successClosure: {(response) in
             success?(File(file: response["file"] as? [String: Any]))


### PR DESCRIPTION
Adds the ability to upload files to a thread by (optionally) allowing `thread_ts` (i.e. thread timestamp) to be specified.

As specified in the Slack API docs:
> **thread_ts**
Provide another message's ts value to upload this file as a reply. Never use a reply's ts value; use its parent instead.

https://api.slack.com/methods/files.upload