### PR TITLE
Remove Vapor websocket to avoid name clash.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,6 @@ let package = Package(
     ],
     dependencies: [
         .package(name: "Swifter", url: "https://github.com/httpswift/swifter.git", .upToNextMinor(from: "1.5.0")),
-        .package(name: "WebSocket", url: "https://github.com/vapor/websocket", .upToNextMinor(from: "1.1.2")),
         .package(name: "Starscream", url: "https://github.com/daltoniam/Starscream", .upToNextMinor(from: "4.0.4"))
     ],
     targets: [
@@ -34,7 +33,6 @@ let package = Package(
                     "SKCore",
                     "SKWebAPI",
                     .product(name: "Starscream", package: "Starscream", condition: .when(platforms: [.macOS, .iOS, .tvOS])),
-                    .product(name: "WebSocket", package: "WebSocket", condition: .when(platforms: [.macOS, .linux])),
                 ],
                 path: "SKRTMAPI/Sources"),
         .target(name: "SKServer",

--- a/SKRTMAPI/Sources/Conformers/VaporEngineRTM.swift
+++ b/SKRTMAPI/Sources/Conformers/VaporEngineRTM.swift
@@ -21,6 +21,7 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
+#if canImport(HTTP)
 #if os(Linux) || os(macOS) && !COCOAPODS
 import Foundation
 import HTTP
@@ -42,7 +43,7 @@ public class VaporEngineRTM: RTMWebSocket {
         guard let host = url.host else {
             fatalError("ERROR - Cannot extract host from '\(url.absoluteString)'")
         }
-        
+
         let scheme: HTTPScheme = url.scheme == "wss" ? .wss : .ws
         futureWebsocket = HTTPClient.webSocket(
             scheme: scheme,
@@ -82,4 +83,5 @@ public class VaporEngineRTM: RTMWebSocket {
         websocket.send(message)
     }
 }
+#endif
 #endif


### PR DESCRIPTION
This is more of a proof of concept for the issue #197.
It may be doable to keep it only for the Linux platform for example.